### PR TITLE
Development branch, release 1.14.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Everyone is welcome to contribute.
 There are several ways to contribute to pytransform3d: you could
 
 * send a bug report to the
-  [bug tracker](http://github.com/rock-learning/pytransform3d/issues)
+  [bug tracker](http://github.com/dfki-ric/pytransform3d/issues)
 * work on one of the reported issues
 * write documentation
 * add a new feature
@@ -19,13 +19,13 @@ This text is shamelessly copied from
 contribution guidelines.
 
 The preferred way to contribute to pytransform3d is to fork the
-[repository](http://github.com/rock-learning/pytransform3d/) on GitHub,
+[repository](http://github.com/dfki-ric/pytransform3d/) on GitHub,
 then submit a "pull request" (PR):
 
 1. [Create an account](https://github.com/signup/free) on
    GitHub if you do not already have one.
 
-2. Fork the [project repository](http://github.com/rock-learning/pytransform3d):
+2. Fork the [project repository](http://github.com/dfki-ric/pytransform3d):
    click on the 'Fork' button near the top of the page. This creates a copy of
    the code under your account on the GitHub server.
 
@@ -59,7 +59,7 @@ repository instead of your forked one, you will need to add another remote
 to use instead of `origin`. If we choose the name `upstream` for it, the
 command will be:
 
-    $ git remote add upstream https://github.com/rock-learning/pytransform3d.git
+    $ git remote add upstream https://github.com/dfki-ric/pytransform3d.git
 
 (If any of the above seems like magic to you, then look up the
 [Git documentation](http://git-scm.com/documentation) on the web.)
@@ -70,7 +70,7 @@ Adding a new feature to pytransform3d requires a few other changes:
 
 * New classes or functions that are part of the public interface must be
   documented. We use [NumPy's conventions for docstrings](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).
-* An entry to the API documentation must be added [here](https://rock-learning.github.io/pytransform3d/api.html).
+* An entry to the API documentation must be added [here](https://dfki-ric.github.io/pytransform3d/api.html).
 * Consider writing a simple example script.
 * Tests: Unit tests for new features are mandatory. They should cover all
   branches. Exceptions are plotting functions, debug outputs, etc. These

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Travis Status](https://travis-ci.org/rock-learning/pytransform3d.svg?branch=master)](https://travis-ci.org/rock-learning/pytransform3d)
-[![CircleCI Status](https://circleci.com/gh/rock-learning/pytransform3d/tree/master.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/rock-learning/pytransform3d)
-[![codecov](https://codecov.io/gh/rock-learning/pytransform3d/branch/master/graph/badge.svg?token=jB10RM3Ujj)](https://codecov.io/gh/rock-learning/pytransform3d)
+[![CircleCI Status](https://circleci.com/gh/dfki-ric/pytransform3d/tree/master.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/dfki-ric/pytransform3d)
+[![codecov](https://codecov.io/gh/dfki-ric/pytransform3d/branch/master/graph/badge.svg?token=jB10RM3Ujj)](https://codecov.io/gh/dfki-ric/pytransform3d)
 [![Paper DOI](http://joss.theoj.org/papers/10.21105/joss.01159/status.svg)](https://doi.org/10.21105/joss.01159)
 [![Release DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2553450.svg)](https://doi.org/10.5281/zenodo.2553450)
 
@@ -98,7 +97,7 @@ python setup.py install
 Also pip supports installation from a git repository:
 
 ```bash
-pip install git+https://github.com/rock-learning/pytransform3d.git
+pip install git+https://github.com/dfki-ric/pytransform3d.git
 ```
 
 Since version 1.8 you can also install pytransform3d with conda from
@@ -109,7 +108,7 @@ for instructions.
 ## Documentation
 
 The API documentation can be found
-[here](https://rock-learning.github.io/pytransform3d/).
+[here](https://dfki-ric.github.io/pytransform3d/).
 
 The documentation can be found in the directory `doc`.
 To build the documentation, run e.g. (on linux):
@@ -164,13 +163,13 @@ ax.set_zlim((0.0, 1.0))
 plt.show()
 ```
 
-![output](https://rock-learning.github.io/pytransform3d/_images/plot_transform_manager.png)
+![output](https://dfki-ric.github.io/pytransform3d/_images/plot_transform_manager.png)
 
 ## Gallery
 
 The following plots and visualizations have been generated with pytransform3d.
 The code for most examples can be found in
-[the documentation](https://rock-learning.github.io/pytransform3d/_auto_examples/index.html).
+[the documentation](https://dfki-ric.github.io/pytransform3d/_auto_examples/index.html).
 
 Left: [Nao robot](https://www.softbankrobotics.com/emea/en/nao) with URDF
 from [Bullet3](https://github.com/bulletphysics/bullet3).
@@ -178,19 +177,19 @@ Right: [Kuka iiwa](https://www.kuka.com/en-de/products/robot-systems/industrial-
 The animation is based on pytransform3d's visualization interface to
 [Open3D](http://www.open3d.org/).
 
-<img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/animation_nao.gif" height=400px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/animation_kuka.gif" height=400px/>
+<img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/animation_nao.gif" height=400px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/animation_kuka.gif" height=400px/>
 
 Visualizations based on [Open3D](http://www.open3d.org/).
 
-<img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/photogrammetry.png" height=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/kuka_trajectories.png" height=300px/>
+<img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/photogrammetry.png" height=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/kuka_trajectories.png" height=300px/>
 
 Various plots based on Matplotlib.
 
-<img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/example_plot_box.png" width=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/cylinders.png" width=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/paper/plot_urdf.png" width=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/transform_manager_mesh.png" width=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/accelerate_cylinder.png" width=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/example_plot_screw.png" width=300px/><img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/doc/source/_static/rotations_axis_angle.png" width=300px/>
+<img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/example_plot_box.png" width=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/cylinders.png" width=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/paper/plot_urdf.png" width=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/transform_manager_mesh.png" width=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/accelerate_cylinder.png" width=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/example_plot_screw.png" width=300px/><img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/doc/source/_static/rotations_axis_angle.png" width=300px/>
 
 Transformation editor based on Qt.
 
-<img src="https://raw.githubusercontent.com/rock-learning/pytransform3d/master/paper/app_transformation_editor.png" height=300px/>
+<img src="https://raw.githubusercontent.com/dfki-ric/pytransform3d/master/paper/app_transformation_editor.png" height=300px/>
 
 ## Tests
 
@@ -205,13 +204,13 @@ the code coverage report.
 ## Contributing
 
 If you wish to report bugs, please use the
-[issue tracker](https://github.com/rock-learning/pytransform3d/issues) at
+[issue tracker](https://github.com/dfki-ric/pytransform3d/issues) at
 Github. If you would like to contribute to pytransform3d, just open an issue
-or a [pull request](https://github.com/rock-learning/pytransform3d/pulls).
+or a [pull request](https://github.com/dfki-ric/pytransform3d/pulls).
 The target branch for pull requests is the develop branch.
 The development branch will be merged to master for new releases.
 If you have questions about the software, you should ask them in the
-[discussion section](https://github.com/rock-learning/pytransform3d/discussions).
+[discussion section](https://github.com/dfki-ric/pytransform3d/discussions).
 
 The recommended workflow to add a new feature, add documentation, or fix a bug
 is the following:
@@ -224,7 +223,7 @@ is the following:
   release will be made.
 
 Note that there is a
-[checklist](https://github.com/rock-learning/pytransform3d/wiki#checklist-for-new-features)
+[checklist](https://github.com/dfki-ric/pytransform3d/wiki#checklist-for-new-features)
 for new features.
 
 It is forbidden to directly push to the main branch (master). Each new version

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -62,7 +62,7 @@ Installation
 ------------
 
 pytransform3d is available at
-`GitHub <https://github.com/rock-learning/pytransform3d>`_.
+`GitHub <https://github.com/dfki-ric/pytransform3d>`_.
 The readme there contains installation instructions. This documentation
 explains how you can work with pytransform3d and with 3D transformations
 in general.

--- a/examples/animations/animate_rotation.py
+++ b/examples/animations/animate_rotation.py
@@ -18,7 +18,7 @@ from pytransform3d import rotations as pr
 
 def update_frame(step, n_frames, frame):
     angle = 2.0 * np.pi * (step + 1) / n_frames
-    R = pr.matrix_from_angle(0, angle)
+    R = pr.passive_matrix_from_angle(0, angle)
     A2B = np.eye(4)
     A2B[:3, :3] = R
     frame.set_data(A2B)

--- a/examples/animations/animate_trajectory.py
+++ b/examples/animations/animate_trajectory.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import axes3d
 import matplotlib.animation as animation
 from pytransform3d.plot_utils import Trajectory
-from pytransform3d.rotations import matrix_from_angle, R_id
+from pytransform3d.rotations import passive_matrix_from_angle, R_id
 from pytransform3d.transformations import transform_from, concat
 
 
@@ -24,7 +24,7 @@ def update_trajectory(step, n_frames, trajectory):
     H_mod = np.eye(4)
     for i, t in enumerate(np.linspace(0, progress, len(H))):
         H0[:3, 3] = np.array([t, 0, t])
-        H_mod[:3, :3] = matrix_from_angle(2, 8 * np.pi * t)
+        H_mod[:3, :3] = passive_matrix_from_angle(2, 8 * np.pi * t)
         H[i] = concat(H0, H_mod)
 
     trajectory.set_data(H)

--- a/examples/visualizations/vis_moving_basis.py
+++ b/examples/visualizations/vis_moving_basis.py
@@ -15,7 +15,7 @@ from pytransform3d import rotations as pr
 
 def animation_callback(step, n_frames, frame):
     angle = 2.0 * np.pi * (step + 1) / n_frames
-    R = pr.matrix_from_angle(0, angle)
+    R = pr.passive_matrix_from_angle(0, angle)
     A2B = np.eye(4)
     A2B[:3, :3] = R
     frame.set_data(A2B)

--- a/examples/visualizations/vis_moving_trajectory.py
+++ b/examples/visualizations/vis_moving_trajectory.py
@@ -10,7 +10,7 @@ print(__doc__)
 
 import numpy as np
 import pytransform3d.visualizer as pv
-from pytransform3d.rotations import matrix_from_angle, R_id
+from pytransform3d.rotations import passive_matrix_from_angle, R_id
 from pytransform3d.transformations import transform_from, concat
 
 
@@ -21,7 +21,7 @@ def update_trajectory(step, n_frames, trajectory):
     H_mod = np.eye(4)
     for i, t in enumerate(np.linspace(0, progress, len(H))):
         H0[:3, 3] = np.array([t, 0, t])
-        H_mod[:3, :3] = matrix_from_angle(2, 8 * np.pi * t)
+        H_mod[:3, :3] = passive_matrix_from_angle(2, 8 * np.pi * t)
         H[i] = concat(H0, H_mod)
 
     trajectory.set_data(H)

--- a/manifest.xml
+++ b/manifest.xml
@@ -5,7 +5,7 @@
   <author>Alexander Fabisch/Alexander.Fabisch@dfki.de</author>
   <maintainer>Alexander Fabisch/Alexander.Fabisch@dfki.de</maintainer>
   <license>BSD-3-clause</license>
-  <url>https://github.com/rock-learning/pytransform3d</url>
+  <url>https://github.com/dfki-ric/pytransform3d</url>
   <logo>none</logo>
 
   <depend package="python" />

--- a/pytransform3d/__init__.py
+++ b/pytransform3d/__init__.py
@@ -1,4 +1,4 @@
 """3D transformations for Python."""
 
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"

--- a/pytransform3d/batch_rotations.py
+++ b/pytransform3d/batch_rotations.py
@@ -312,7 +312,7 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
     out[..., 2] = Rs[..., 1, 0] - Rs[..., 0, 1]
 
     # The threshold is a result from this discussion:
-    # https://github.com/rock-learning/pytransform3d/issues/43
+    # https://github.com/dfki-ric/pytransform3d/issues/43
     # The standard formula becomes numerically unstable, however,
     # Rodrigues' formula reduces to R = I + 2 (ee^T - I), with the
     # rotation axis e, that is, ee^T = 0.5 * (R + I) and we can find the

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -1637,7 +1637,7 @@ def axis_angle_from_matrix(R, strict_check=True, check=True):
         [R[2, 1] - R[1, 2], R[0, 2] - R[2, 0], R[1, 0] - R[0, 1]])
 
     if abs(angle - np.pi) < 1e-4:  # np.trace(R) close to -1
-        # The threshold is a result from this discussion:
+        # The threshold 1e-4 is a result from this discussion:
         # https://github.com/rock-learning/pytransform3d/issues/43
         # The standard formula becomes numerically unstable, however,
         # Rodrigues' formula reduces to R = I + 2 (ee^T - I), with the
@@ -1645,7 +1645,11 @@ def axis_angle_from_matrix(R, strict_check=True, check=True):
         # squared values of the rotation axis on the diagonal of this matrix.
         # We can still use the original formula to reconstruct the signs of
         # the rotation axis correctly.
-        a[:3] = np.sqrt(0.5 * (np.diag(R) + 1.0)) * np.sign(axis_unnormalized)
+
+        # In case of floating point inaccuracies:
+        R_diag = np.clip(np.diag(R), -1.0, 1.0)
+
+        a[:3] = np.sqrt(0.5 * (R_diag + 1.0)) * np.sign(axis_unnormalized)
     else:
         a[:3] = axis_unnormalized
         # The norm of axis_unnormalized is 2.0 * np.sin(angle), that is, we

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -915,7 +915,7 @@ def _general_intrinsic_euler_from_active_matrix(
     """General algorithm to extract intrinsic euler angles from a matrix.
 
     The implementation is based on SciPy's implementation:
-    https://github.com/scipy/scipy/blob/master/scipy/spatial/transform/rotation.pyx
+    https://github.com/scipy/scipy/blob/743c283bbe79473a03ca2eddaa537661846d8a19/scipy/spatial/transform/_rotation.pyx
 
     Parameters
     ----------

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -1,5 +1,6 @@
 """Conversions between rotation representations."""
 import math
+import warnings
 import numpy as np
 from ._utils import (
     check_matrix, check_quaternion, check_axis_angle, check_compact_axis_angle,
@@ -183,7 +184,7 @@ def matrix_from_quaternion(q):
     return R
 
 
-def matrix_from_angle(basis, angle):
+def passive_matrix_from_angle(basis, angle):
     """Compute passive rotation matrix from rotation about basis vector.
 
     Parameters
@@ -225,7 +226,48 @@ def matrix_from_angle(basis, angle):
     return R
 
 
-passive_matrix_from_angle = matrix_from_angle
+def matrix_from_angle(basis, angle):
+    """Compute passive rotation matrix from rotation about basis vector.
+
+    Parameters
+    ----------
+    basis : int from [0, 1, 2]
+        The rotation axis (0: x, 1: y, 2: z)
+
+    angle : float
+        Rotation angle
+
+    Returns
+    -------
+    R : array-like, shape (3, 3)
+        Rotation matrix
+
+    Raises
+    ------
+    ValueError
+        If basis is invalid
+    """
+    warnings.warn("matrix_from_angle will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
+    c = np.cos(angle)
+    s = np.sin(angle)
+
+    if basis == 0:
+        R = np.array([[1.0, 0.0, 0.0],
+                      [0.0, c, s],
+                      [0.0, -s, c]])
+    elif basis == 1:
+        R = np.array([[c, 0.0, -s],
+                      [0.0, 1.0, 0.0],
+                      [s, 0.0, c]])
+    elif basis == 2:
+        R = np.array([[c, s, 0.0],
+                      [-s, c, 0.0],
+                      [0.0, 0.0, 1.0]])
+    else:
+        raise ValueError("Basis must be in [0, 1, 2]")
+
+    return R
 
 
 def active_matrix_from_angle(basis, angle):
@@ -283,6 +325,8 @@ def matrix_from_euler_xyz(e):
     R : array-like, shape (3, 3)
         Rotation matrix
     """
+    warnings.warn("matrix_from_euler_xyz will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     alpha, beta, gamma = e
     R = passive_matrix_from_angle(0, alpha).dot(
         passive_matrix_from_angle(1, beta)).dot(
@@ -303,6 +347,8 @@ def matrix_from_euler_zyx(e):
     R : array, shape (3, 3)
         Rotation matrix
     """
+    warnings.warn("matrix_from_euler_zyx will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     gamma, beta, alpha = e
     R = passive_matrix_from_angle(2, gamma).dot(
         passive_matrix_from_angle(1, beta)).dot(
@@ -849,6 +895,8 @@ def matrix_from(R=None, a=None, q=None, e_xyz=None, e_zyx=None):
     ValueError
         If no rotation is given
     """
+    warnings.warn("matrix_from will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     if R is not None:
         return R
     if a is not None:
@@ -982,6 +1030,8 @@ def euler_xyz_from_matrix(R, strict_check=True):
     e_xyz : array-like, shape (3,)
         Angles for rotation around x-, y'-, and z''-axes (intrinsic rotations)
     """
+    warnings.warn("euler_xyz_from_matrix will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     R = check_matrix(R, strict_check=strict_check)
     if np.abs(R[0, 2]) != 1.0:
         # NOTE: There are two solutions: angle2 and pi - angle2!
@@ -1017,6 +1067,8 @@ def euler_zyx_from_matrix(R, strict_check=True):
     e_zyx : array-like, shape (3,)
         Angles for rotation around z-, y'-, and x''-axes (intrinsic rotations)
     """
+    warnings.warn("euler_zyx_from_matrix will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     R = check_matrix(R, strict_check=strict_check)
     if np.abs(R[2, 0]) != 1.0:
         # NOTE: There are two solutions: angle2 and pi - angle2!

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -1638,7 +1638,7 @@ def axis_angle_from_matrix(R, strict_check=True, check=True):
 
     if abs(angle - np.pi) < 1e-4:  # np.trace(R) close to -1
         # The threshold 1e-4 is a result from this discussion:
-        # https://github.com/rock-learning/pytransform3d/issues/43
+        # https://github.com/dfki-ric/pytransform3d/issues/43
         # The standard formula becomes numerically unstable, however,
         # Rodrigues' formula reduces to R = I + 2 (ee^T - I), with the
         # rotation axis e, that is, ee^T = 0.5 * (R + I) and we can find the

--- a/pytransform3d/rotations/_testing.py
+++ b/pytransform3d/rotations/_testing.py
@@ -1,4 +1,5 @@
 """Testing utilities."""
+import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from ._utils import norm_axis_angle, norm_compact_axis_angle
@@ -126,6 +127,8 @@ def assert_euler_xyz_equal(e_xyz1, e_xyz2, *args, **kwargs):
         Positional arguments that will be passed to
         `assert_array_almost_equal`
     """
+    warnings.warn("assert_euler_xyz_equal will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     R1 = matrix_from_euler_xyz(e_xyz1)
     R2 = matrix_from_euler_xyz(e_xyz2)
     assert_array_almost_equal(R1, R2, *args, **kwargs)
@@ -155,6 +158,8 @@ def assert_euler_zyx_equal(e_zyx1, e_zyx2, *args, **kwargs):
         Positional arguments that will be passed to
         `assert_array_almost_equal`
     """
+    warnings.warn("assert_euler_zyx_equal will be removed in version 2.0.0",
+                  DeprecationWarning, stacklevel=2)
     R1 = matrix_from_euler_zyx(e_zyx1)
     R2 = matrix_from_euler_zyx(e_zyx2)
     assert_array_almost_equal(R1, R2, *args, **kwargs)

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1936,3 +1936,18 @@ def test_pick_closest_quaternion():
         q = pr.random_quaternion(random_state)
         assert_array_almost_equal(pr.pick_closest_quaternion(q, q), q)
         assert_array_almost_equal(pr.pick_closest_quaternion(-q, q), q)
+
+
+def test_bug_189():
+    """Test bug #189"""
+    R = np.array([
+        [-1.0000000000000004e+00, 2.8285718503485576e-16,
+         1.0966597378775709e-16],
+        [1.0966597378775709e-16, -2.2204460492503131e-16,
+         1.0000000000000002e+00],
+        [2.8285718503485576e-16, 1.0000000000000002e+00,
+         -2.2204460492503131e-16]
+    ])
+    a1 = pr.compact_axis_angle_from_matrix(R)
+    a2 = pr.compact_axis_angle_from_matrix(pr.norm_matrix(R))
+    assert_array_almost_equal(a1, a2)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
           version=pytransform3d.__version__,
           author='Alexander Fabisch',
           author_email='afabisch@googlemail.com',
-          url='https://github.com/rock-learning/pytransform3d',
+          url='https://github.com/dfki-ric/pytransform3d',
           description='3D transformations for Python',
           long_description=long_description,
           long_description_content_type="text/markdown",


### PR DESCRIPTION
## Bugfixes

- Fix `pytransform3d.rotations.axis_angle_from_matrix` with floating point precision errors in input rotation matrix (#189)

## Deprecations

- pytransform3d.rotations.matrix_from
- pytransform3d.rotations.matrix_from_angle
- pytransform3d.rotations.matrix_from_euler_xyz
- pytransform3d.rotations.matrix_from_euler_zyx
- pytransform3d.rotations.euler_xyz_from_matrix
- pytransform3d.rotations.euler_zyx_from_matrix
- pytransform3d.rotations.assert_euler_xyz_equal
- pytransform3d.rotations.assert_euler_zyx_equal
- pytransform3d.rotations.e_xyz_id
- pytransform3d.rotations.e_zyx_id

## Documentation

- Changed URL to https://github.com/dfki-ric/pytransform3d