### PR TITLE
Raise ValueError when no quaternion is given

### DIFF
--- a/pytransform3d/batch_rotations.py
+++ b/pytransform3d/batch_rotations.py
@@ -691,8 +691,16 @@ def smooth_quaternion_trajectory(Q, start_component_positive="x"):
     -------
     Q : array, shape (n_steps, 4)
         Unit quaternions to represent rotations: (w, x, y, z)
+
+    Raises
+    ------
+    ValueError
+        If Q has length 0.
     """
     Q = np.copy(Q)
+
+    if len(Q) == 0:
+        raise ValueError("At least one quaternion is expected.")
 
     if Q[0, "wxyz".index(start_component_positive)] < 0.0:
         Q[0] *= -1.0

--- a/pytransform3d/test/test_batch_rotations.py
+++ b/pytransform3d/test/test_batch_rotations.py
@@ -477,3 +477,9 @@ def test_smooth_quaternion_trajectory_start_component_negative():
         q_corrected = pbr.smooth_quaternion_trajectory(
             [q], start_component_positive=component)[0]
         assert_greater(q_corrected[index], 0.0)
+
+
+def test_smooth_quaternion_trajectory_empty():
+    assert_raises_regexp(
+        ValueError, "At least one quaternion is expected",
+        pbr.smooth_quaternion_trajectory, np.zeros((0, 4)))


### PR DESCRIPTION
...in function smooth_quaternion_trajectory

Fix #187 
