### PR TITLE
chore: draft change

### DIFF
--- a/pytransform3d/test/test_urdf.py
+++ b/pytransform3d/test/test_urdf.py
@@ -3,8 +3,8 @@ try:
     matplotlib_available = True
 except ImportError:
     matplotlib_available = False
-import warnings
 import numpy as np
+import warnings
 from pytransform3d.urdf import (
     UrdfTransformManager, UrdfException, parse_urdf,
     initialize_urdf_transform_manager)
@@ -363,6 +363,14 @@ def test_joint_limit_clipping():
     )
 
 
+def test_joint_limit_clipping_warning():
+    tm = UrdfTransformManager()
+    tm.load_urdf(COMPI_URDF)
+    with warnings.catch_warnings(record=True) as w:
+        tm.set_joint("joint1", 2.0)
+    assert_equal(len(w), 1)
+
+
 def test_fixed_joint():
     tm = UrdfTransformManager()
     tm.load_urdf(COMPI_URDF)
@@ -373,6 +381,26 @@ def test_fixed_joint():
                   [0, 1, 0, 0],
                   [0, 0, 1, 1.174],
                   [0, 0, 0, 1]])
+    )
+
+
+def test_fixed_joint_warning():
+    tm = UrdfTransformManager()
+    tm.load_urdf(COMPI_URDF)
+    with warnings.catch_warnings(record=True) as w:
+        tm.set_joint("jointtcp", 0.0)
+    assert_equal(len(w), 1)
+
+
+def test_fixed_joint_unchanged():
+    tm = UrdfTransformManager()
+    tm.load_urdf(COMPI_URDF)
+    tcp_to_link0_before = tm.get_transform("tcp", "linkmount")
+    tm.set_joint("jointtcp", 2.0)
+    tcp_to_link0_after = tm.get_transform("tcp", "linkmount")
+    assert_array_almost_equal(
+        tcp_to_link0_before,
+        tcp_to_link0_after
     )
 
 

--- a/pytransform3d/test/test_urdf.py
+++ b/pytransform3d/test/test_urdf.py
@@ -363,14 +363,6 @@ def test_joint_limit_clipping():
     )
 
 
-def test_joint_limit_clipping_warning():
-    tm = UrdfTransformManager()
-    tm.load_urdf(COMPI_URDF)
-    with warnings.catch_warnings(record=True) as w:
-        tm.set_joint("joint1", 2.0)
-    assert_equal(len(w), 1)
-
-
 def test_fixed_joint():
     tm = UrdfTransformManager()
     tm.load_urdf(COMPI_URDF)

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -103,16 +103,14 @@ class UrdfTransformManager(TransformManager):
         from_frame, to_frame, child2parent, axis, limits, joint_type = \
             self._joints[joint_name]
         # this is way faster than np.clip:
-        value_lim = min(max(value, limits[0]), limits[1])
-        if value_lim != value:
-            warnings.warn(f"Value for {joint_name} is capped by limits")
+        value = min(max(value, limits[0]), limits[1])
         if joint_type == "revolute":
             joint_rotation = matrix_from_axis_angle(
-                np.hstack((axis, (value_lim,))))
+                np.hstack((axis, (value,))))
             joint2A = transform_from(
                 joint_rotation, np.zeros(3), strict_check=self.strict_check)
         elif joint_type == "prismatic":
-            joint_offset = value_lim * axis
+            joint_offset = value * axis
             joint2A = transform_from(
                 np.eye(3), joint_offset, strict_check=self.strict_check)
         else:

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -646,7 +646,7 @@ def _add_joints(tm, joints):
             assert joint.joint_type == "fixed"
             tm.add_joint(
                 joint.joint_name, joint.child, joint.parent,
-                joint.child2parent, joint.joint_axis, joint.limits,
+                joint.child2parent, joint.joint_axis, (0.0, 0.0),
                 "fixed")
 
 

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -108,11 +108,14 @@ class UrdfTransformManager(TransformManager):
                 np.hstack((axis, (value,))))
             joint2A = transform_from(
                 joint_rotation, np.zeros(3), strict_check=self.strict_check)
-        else:
-            assert joint_type == "prismatic"
+        elif joint_type == "prismatic":
             joint_offset = value * axis
             joint2A = transform_from(
                 np.eye(3), joint_offset, strict_check=self.strict_check)
+        else:
+            assert joint_type == "fixed"
+            print("WARNING: Fixed joint cannot be set")
+            return
         self.add_transform(from_frame, to_frame, concat(
             joint2A, child2parent, strict_check=self.strict_check,
             check=self.check))
@@ -641,7 +644,10 @@ def _add_joints(tm, joints):
                 "prismatic")
         else:
             assert joint.joint_type == "fixed"
-            tm.add_transform(joint.child, joint.parent, joint.child2parent)
+            tm.add_joint(
+                joint.joint_name, joint.child, joint.parent,
+                joint.child2parent, joint.joint_axis, joint.limits,
+                "fixed")
 
 
 class Link(object):


### PR DESCRIPTION
hi @AlexanderFabisch , I appreciate your work on this package! I have been playing around with it and am now building a small development tool that uses this package. 

For my application it would be very helpful if fixed joints can also be identified based on their 'joint_name' and not only via their 'from_name' + 'to_name' combination. Please find attached a draft change. 

Note:
- I did not run the unit tests yet so it's very possible that the current suggestion causes integration issues
- I did not change _get_joint_limits_ since a fixed joint will also have these limits defined.

Curious to hear your thoughts. Perhaps there is a clear reason not to do this. In that case I will solve it locally in my code.