### PR TITLE
[WIP] Fix check of det of rotation matrix

### DIFF
--- a/pytransform3d/rotations/_utils.py
+++ b/pytransform3d/rotations/_utils.py
@@ -427,7 +427,7 @@ def check_matrix(R, tolerance=1e-6, strict_check=True):
             raise ValueError(error_msg)
         warnings.warn(error_msg)
     R_det = np.linalg.det(R)
-    if abs(R_det - 1) > tolerance:
+    if R_det < 0.0:
         error_msg = ("Expected rotation matrix, but it failed the test "
                      "for the determinant, which should be 1 but is %g; "
                      "that is, it probably represents a rotoreflection"

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1708,7 +1708,7 @@ def test_deactivate_rotation_matrix_precision_error():
         pr.check_matrix(R)
     with warnings.catch_warnings(record=True) as w:
         pr.check_matrix(R, strict_check=False)
-        assert len(w) == 2
+        assert len(w) == 1
 
 
 def test_norm_rotation_matrix():

--- a/pytransform3d/test/test_transform_manager.py
+++ b/pytransform3d/test/test_transform_manager.py
@@ -1,7 +1,6 @@
 import os
 import pickle
 import warnings
-import platform
 import tempfile
 import numpy as np
 from pytransform3d.rotations import (
@@ -248,11 +247,7 @@ def test_deactivate_transform_manager_precision_error():
     with pytest.raises(ValueError, match="Expected rotation matrix"):
         tm.add_transform("A", "B", A2B)
 
-    if int(platform.python_version()[0]) == 2:
-        # Python 2 seems to incorrectly suppress some warnings, not sure why
-        n_expected_warnings = 7
-    else:
-        n_expected_warnings = 9
+    n_expected_warnings = 6
     try:
         warnings.filterwarnings("always", category=UserWarning)
         with warnings.catch_warnings(record=True) as w:

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -1,5 +1,4 @@
 import warnings
-import platform
 import numpy as np
 import pytest
 
@@ -264,11 +263,7 @@ def test_deactivate_transform_precision_error():
     with pytest.raises(ValueError, match="Expected rotation matrix"):
         check_transform(A2B)
 
-    if int(platform.python_version()[0]) == 2:
-        # Python 2 seems to incorrectly suppress some warnings, not sure why
-        n_expected_warnings = 2
-    else:
-        n_expected_warnings = 3
+    n_expected_warnings = 2
     try:
         warnings.filterwarnings("always", category=UserWarning)
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Fixes #218 

Numerical error of the determinant is (only a bit) larger than the error in individual components of the rotation matrix multiplied with its transpose.

```python
def test_rotation_matrix_precision_error():
    R = pr.active_matrix_from_extrinsic_roll_pitch_yaw([0.5, 0.5, 0.5])
    for _ in range(40):
        R = R.dot(R)
        det_error = abs(1.0 - np.linalg.det(R))
        RRT_error = np.max(R.dot(R.T) - np.eye(3))
        assert RRT_error <= det_error
```

Hence, we don't have to check whether det(R) is 1. We just have to check for reflection.