### PR TITLE
Fix and test edge case for matrix conversion

### DIFF
--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -992,6 +992,10 @@ def _general_intrinsic_euler_from_active_matrix(
 
     # Step 4
     # - Equation 10a
+    if abs(O[2, 2] - 1.0) == np.finfo(float).eps:
+        O[2, 2] = 1.0
+    elif abs(O[2, 2] - 0.0) == np.finfo(float).eps:
+        O[2, 2] = 0.0
     beta = lmbda + np.arccos(O[2, 2])
 
     safe1 = abs(beta - lmbda) >= np.finfo(float).eps

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -992,9 +992,9 @@ def _general_intrinsic_euler_from_active_matrix(
 
     # Step 4
     # - Equation 10a
-    if abs(O[2, 2] - 1.0) == np.finfo(float).eps:
+    if abs(O[2, 2] - 1.0) <= np.finfo(float).eps:
         O[2, 2] = 1.0
-    elif abs(O[2, 2] - 0.0) == np.finfo(float).eps:
+    elif abs(O[2, 2] - 0.0) <= np.finfo(float).eps:
         O[2, 2] = 0.0
     beta = lmbda + np.arccos(O[2, 2])
 

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -2225,3 +2225,9 @@ def test_jacobian_so3():
 
         J_inv_J = np.dot(J_inv, J)
         assert_array_almost_equal(J_inv_J, np.eye(3))
+
+def test_euler_from_quaternion_edge_case():
+    quaternion = [0.57114154, -0.41689009, -0.57114154, -0.41689009]
+    matrix = pr.matrix_from_quaternion(quaternion)
+    euler_xyz = pr.extrinsic_euler_xyz_from_active_matrix(matrix)
+    assert not np.isnan(euler_xyz).all()

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -2226,8 +2226,10 @@ def test_jacobian_so3():
         J_inv_J = np.dot(J_inv, J)
         assert_array_almost_equal(J_inv_J, np.eye(3))
 
+
 def test_euler_from_quaternion_edge_case():
     quaternion = [0.57114154, -0.41689009, -0.57114154, -0.41689009]
     matrix = pr.matrix_from_quaternion(quaternion)
     euler_xyz = pr.extrinsic_euler_xyz_from_active_matrix(matrix)
     assert not np.isnan(euler_xyz).all()
+    


### PR DESCRIPTION
There's a slight edge case I found due to numerical instability where the matrix conversion will error for arccosine if the value is 1.0 + epsilon and provide a NaN value. It will trigger specifically the code path in lines 995-996 but I have not found an orientation that triggers 997-998. If you want, I can remove that code path or add a corresponding test. 