### PR TITLE
Fix arccos numerical issue in axis_angle_from_two_directions

### DIFF
--- a/pytransform3d/batch_rotations.py
+++ b/pytransform3d/batch_rotations.py
@@ -302,7 +302,7 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
             # out[False, n] = value will not assign value to out[n]
             traces = traces[0]
 
-    angles = np.arccos((traces - 1.0) / 2.0)
+    angles = np.arccos(np.clip((traces - 1.0) / 2.0, -1, 1))
 
     if out is None:
         out = np.empty(instances_shape + (4,))

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -1813,7 +1813,8 @@ def axis_angle_from_quaternion(q):
         return np.array([1.0, 0.0, 0.0, 0.0])
 
     axis = p / p_norm
-    angle = (2.0 * np.arccos(q[0]),)
+    w_clamped = max(min(q[0], 1.0), -1.0)
+    angle = (2.0 * np.arccos(w_clamped),)
     return norm_axis_angle(np.hstack((axis, angle)))
 
 

--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -1875,7 +1875,7 @@ def axis_angle_from_two_directions(a, b):
         axis = np.cross(a, b)
     aa = np.empty(4)
     aa[:3] = norm_vector(axis)
-    aa[3] = np.arccos(cos_angle)
+    aa[3] = np.arccos(max(min(cos_angle, 1.0), -1.0))
     return norm_axis_angle(aa)
 
 


### PR DESCRIPTION
There was an issue with arccos similar to https://github.com/dfki-ric/pytransform3d/pull/247, so I've clamped the bounds similar to how you've done this in other areas of the code with arccos

All other arccos instances in the `_conversions` file are clamped, except for this and one other place - in `axis_angle_from_quaternion`. Should I clamp that one as well?
