### PR TITLE
fix axis angle conversion when the rotation matrix is close to identity

### DIFF
--- a/pytransform3d/rotations/_conversions.py
+++ b/pytransform3d/rotations/_conversions.py
@@ -1751,7 +1751,7 @@ def axis_angle_from_matrix(R, strict_check=True, check=True):
     cos_angle = (np.trace(R) - 1.0) / 2.0
     angle = np.arccos(min(max(-1.0, cos_angle), 1.0))
 
-    if angle == 0.0:  # R == np.eye(3)
+    if np.isclose(angle, 0, atol=1e-6):  # R == np.eye(3)
         return np.array([1.0, 0.0, 0.0, 0.0])
 
     a = np.empty(4)


### PR DESCRIPTION
Fix rotation matrix to axis-angle conversion for near-identity matrices

Description:
This PR fixes the rotation matrix to axis-angle conversion when the matrix is close to identity. The current implementation uses strict equality (==) to check for identity, which fails due to float precision issues. This can lead to division by zero and NaN results.

This fix prevents NaN outputs and ensures accurate conversion for small rotations.