### PR TITLE
Update `pip install` installation instructions to work on Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Execute the following command in the main folder of the repository
 to install the dependencies:
 
 ```bash
-pip install -e .[doc]
+pip install -e '.[doc]'
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ I gave a talk at EuroSciPy 2023 about pytransform3d. Slides are available
 Use pip to install the package from PyPI:
 
 ```bash
-pip install pytransform3d[all]
+pip install 'pytransform3d[all]'
 ```
 
 or conda:

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -33,7 +33,7 @@ For example, you can call
 
 .. code-block:: bash
 
-    python -m pip install pytransform3d[all]
+    python -m pip install 'pytransform3d[all]'
 
 Unfortunately, pip cannot install all dependencies:
 


### PR DESCRIPTION
Zsh users (or MacOS users, which have [Zsh](https://www.zsh.org/) as default from 2020) will encounter problems following the README, e.g.:

```
(.venv) kopytjuk in ~/Code/example-project ● λ pip install pytransform3d[all]
zsh: no matches found: pytransform3d[all]
```

The reason for this, that Zsh uses `[]` for some string generation, see SO answer [here](https://apple.stackexchange.com/a/427617).

This PR fixes is, by wrapping the command in quotes. It works on both `bash` and `zsh`.