### PR TITLE
Add Python releases 3.12 and 3.13 to CI 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.12 and 3.13 are released and should be tested in GHA as well:

![image](https://github.com/user-attachments/assets/43dca650-7bd6-4921-957b-5729d342de87)
