### PR TITLE
Normalization of dual quaternions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -414,6 +414,7 @@ Dual Quaternion
    ~check_dual_quaternion
 
    ~dual_quaternion_requires_renormalization
+   ~norm_dual_quaternion
 
    ~assert_unit_dual_quaternion
    ~assert_unit_dual_quaternion_equal

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -603,6 +603,13 @@ def test_check_dual_quaternion():
     dq4 = pt.check_dual_quaternion(dq3, unit=True)
     assert not pt.dual_quaternion_requires_renormalization(dq4)
 
+    dq5 = np.array([
+        0.94508498, 0.0617101, -0.06483886, 0.31432811,
+        -0.07743254, 0.04985168, -0.26119618, 0.1691491])
+    dq5_not_orthogonal = np.copy(dq5)
+    dq5_not_orthogonal[4:] = np.round(dq5_not_orthogonal[4:], 1)
+    assert pt.dual_quaternion_requires_renormalization(dq5_not_orthogonal)
+
 
 def test_normalize_dual_quaternion():
     dq = [1, 0, 0, 0, 0, 0, 0, 0]

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -616,18 +616,32 @@ def test_normalize_dual_quaternion():
     dq_norm = pt.check_dual_quaternion(dq)
     pt.assert_unit_dual_quaternion(dq_norm)
     assert_array_almost_equal(dq, dq_norm)
+    assert_array_almost_equal(dq, pt.norm_dual_quaternion(dq))
 
     dq = [0, 0, 0, 0, 0, 0, 0, 0]
     dq_norm = pt.check_dual_quaternion(dq)
     pt.assert_unit_dual_quaternion(dq_norm)
     assert_array_almost_equal([1, 0, 0, 0, 0, 0, 0, 0], dq_norm)
+    assert_array_almost_equal(dq_norm, pt.norm_dual_quaternion(dq))
 
     rng = np.random.default_rng(999)
-    for _ in range(5):
+    for _ in range(5):  # norm != 1
         A2B = pt.random_transform(rng)
         dq = rng.standard_normal() * pt.dual_quaternion_from_transform(A2B)
         dq_norm = pt.check_dual_quaternion(dq)
         pt.assert_unit_dual_quaternion(dq_norm)
+        assert_array_almost_equal(dq_norm, pt.norm_dual_quaternion(dq))
+
+    for _ in range(5):  # real and dual quaternion are not orthogonal
+        A2B = pt.random_transform(rng)
+        dq = pt.dual_quaternion_from_transform(A2B)
+        dq_roundoff_error = np.copy(dq)
+        dq_roundoff_error[4:] = np.round(dq_roundoff_error[4:], 3)
+        assert pt.dual_quaternion_requires_renormalization(dq_roundoff_error)
+        dq_norm = pt.norm_dual_quaternion(dq_roundoff_error)
+        pt.assert_unit_dual_quaternion(dq_norm)
+        assert not pt.dual_quaternion_requires_renormalization(dq_norm)
+        assert_array_almost_equal(dq, dq_norm, decimal=3)
 
 
 def test_conversions_between_dual_quternion_and_transform():

--- a/pytransform3d/transformations/__init__.py
+++ b/pytransform3d/transformations/__init__.py
@@ -31,8 +31,9 @@ from ._transform_operations import (
     vectors_to_directions, transform)
 from ._pq_operations import pq_slerp
 from ._dual_quaternion_operations import (
-    dual_quaternion_double, dq_q_conj, dq_conj, concatenate_dual_quaternions,
-    dual_quaternion_sclerp, dual_quaternion_power, dq_prod_vector)
+    norm_dual_quaternion, dual_quaternion_double, dq_q_conj, dq_conj,
+    concatenate_dual_quaternions, dual_quaternion_sclerp,
+    dual_quaternion_power, dq_prod_vector)
 from ._random import (
     random_transform, random_screw_axis, random_exponential_coordinates)
 from ._plot import plot_transform, plot_screw
@@ -74,7 +75,7 @@ __all__ = [
     "vectors_to_directions", "transform",
     "random_transform", "random_screw_axis", "random_exponential_coordinates",
     "pq_slerp",
-    "dual_quaternion_double", "dq_q_conj", "dq_conj",
+    "norm_dual_quaternion", "dual_quaternion_double", "dq_q_conj", "dq_conj",
     "concatenate_dual_quaternions", "dual_quaternion_sclerp",
     "dual_quaternion_power", "dq_prod_vector",
     "plot_transform", "plot_screw",

--- a/pytransform3d/transformations/_dual_quaternion_operations.py
+++ b/pytransform3d/transformations/_dual_quaternion_operations.py
@@ -24,6 +24,15 @@ def norm_dual_quaternion(dq):
         Unit dual quaternion to represent transform with orthogonal real and
         dual quaternion.
 
+    See Also
+    --------
+    check_dual_quaternion
+        Input validation of dual quaternion representation. Has an option to
+        normalize the dual quaternion.
+
+    dual_quaternion_requires_renormalization
+        Check if normalization is required.
+
     References
     ----------
     .. [1] enki (2023). Properly normalizing a dual quaternion.

--- a/pytransform3d/transformations/_dual_quaternion_operations.py
+++ b/pytransform3d/transformations/_dual_quaternion_operations.py
@@ -10,7 +10,10 @@ def norm_dual_quaternion(dq):
     """Normalize unit dual quaternion.
 
     A unit dual quaternion has a real quaternion with unit norm and an
-    orthogonal real part.
+    orthogonal real part. Both properties are enforced by multiplying a
+    normalization factor [1]_. This is not always necessary. It is often
+    sufficient to only enforce the unit norm property of the real quaternion.
+    This can also be done with :func:`check_dual_quaternion`.
 
     Parameters
     ----------

--- a/pytransform3d/transformations/_dual_quaternion_operations.pyi
+++ b/pytransform3d/transformations/_dual_quaternion_operations.pyi
@@ -2,6 +2,9 @@ import numpy as np
 import numpy.typing as npt
 
 
+def norm_dual_quaternion(dq: npt.ArrayLike) -> np.ndarray: ...
+
+
 def dual_quaternion_double(dq: npt.ArrayLike) -> np.ndarray: ...
 
 
@@ -12,7 +15,8 @@ def dq_q_conj(dq: npt.ArrayLike) -> np.ndarray: ...
 
 
 def concatenate_dual_quaternions(
-        dq1: npt.ArrayLike, dq2: npt.ArrayLike) -> np.ndarray: ...
+        dq1: npt.ArrayLike, dq2: npt.ArrayLike,
+        unit: bool = ...) -> np.ndarray: ...
 
 
 def dq_prod_vector(dq: npt.ArrayLike, v: npt.ArrayLike) -> np.ndarray: ...

--- a/pytransform3d/transformations/_testing.py
+++ b/pytransform3d/transformations/_testing.py
@@ -80,6 +80,19 @@ def assert_unit_dual_quaternion(dq, *args, **kwargs):
     kwargs : dict
         Positional arguments that will be passed to
         `assert_array_almost_equal`
+
+    See Also
+    --------
+    check_dual_quaternion
+        Input validation of dual quaternion representation. Has an option to
+        normalize the dual quaternion.
+
+    dual_quaternion_requires_renormalization
+        Check if normalization is required.
+
+    norm_dual_quaternion
+        Normalization that enforces unit norm and orthogonality of the real and
+        dual quaternion.
     """
     real = dq[:4]
     dual = dq[4:]

--- a/pytransform3d/transformations/_utils.py
+++ b/pytransform3d/transformations/_utils.py
@@ -377,8 +377,8 @@ def dual_quaternion_requires_renormalization(dq, tolerance=1e-6):
     r"""Check if dual quaternion requires renormalization.
 
     Dual quaternions that represent transformations in 3D should have unit
-    norm. Since the real and the dual quaternion are orthogonal, their
-    product is 0. In addition, :math:`\epsilon^2 = 0`. Hence,
+    norm. Since the real and the dual quaternion are orthogonal, their dot
+    product should be 0. In addition, :math:`\epsilon^2 = 0`. Hence,
 
     .. math::
 
@@ -394,6 +394,9 @@ def dual_quaternion_requires_renormalization(dq, tolerance=1e-6):
         \sqrt{\boldsymbol{p}\cdot\boldsymbol{p}},
 
     i.e., the norm only depends on the real quaternion.
+
+    This function checks unit norm and orthogonality of the real and dual
+    part.
 
     Parameters
     ----------
@@ -415,7 +418,11 @@ def dual_quaternion_requires_renormalization(dq, tolerance=1e-6):
         Input validation of dual quaternion representation. Has an option to
         normalize the dual quaternion.
     """
-    return abs(np.linalg.norm(dq[:4]) - 1.0) > tolerance
+    real = dq[:4]
+    dual = dq[4:]
+    real_norm = np.linalg.norm(real)
+    real_dual_dot = np.dot(real, dual)
+    return abs(real_norm - 1.0) > tolerance or abs(real_dual_dot) > tolerance
 
 
 def check_dual_quaternion(dq, unit=True):

--- a/pytransform3d/transformations/_utils.py
+++ b/pytransform3d/transformations/_utils.py
@@ -417,6 +417,13 @@ def dual_quaternion_requires_renormalization(dq, tolerance=1e-6):
     check_dual_quaternion
         Input validation of dual quaternion representation. Has an option to
         normalize the dual quaternion.
+
+    norm_dual_quaternion
+        Normalization that enforces unit norm and orthogonality of the real and
+        dual quaternion.
+
+    assert_unit_dual_quaternion
+        Checks unit norm and orthogonality of real and dual quaternion.
     """
     real = dq[:4]
     dual = dq[4:]
@@ -463,6 +470,12 @@ def check_dual_quaternion(dq, unit=True):
     ------
     ValueError
         If input is invalid
+
+    See Also
+    --------
+    norm_dual_quaternion
+        Normalization that enforces unit norm and orthogonality of the real and
+        dual quaternion.
     """
     dq = np.asarray(dq, dtype=np.float64)
     if dq.ndim != 1 or dq.shape[0] != 8:


### PR DESCRIPTION
- Add `transformations.norm_dual_quaternion`
- Add option `unit` to `transformations.concatenate_dual_quaternions` to allow multiplication of unnormalized dual quaternions
- Update `transformations.dual_quaternion_requires_renormalization` to check for orthogonality of real and dual quaternion