### PR TITLE
Replaced matrices_from_pos_quat with transforms_from_pqs in plot_trajectory

### DIFF
--- a/pytransform3d/visualizer/_figure.py
+++ b/pytransform3d/visualizer/_figure.py
@@ -380,7 +380,7 @@ class Figure:
         trajectory : Trajectory
             New trajectory.
         """
-        H = ptr.matrices_from_pos_quat(P)
+        H = ptr.transforms_from_pqs(P)
         trajectory = Trajectory(H, n_frames, s, c)
         trajectory.add_artist(self)
         return trajectory


### PR DESCRIPTION
It seems that matrices_from_pos_quat is deprecated in the new version, here I replace it with transforms_from_pqs