### PR TITLE
Fix for URDF parsing with XML namespace

### DIFF
--- a/pytransform3d/test/test_urdf.py
+++ b/pytransform3d/test/test_urdf.py
@@ -191,6 +191,36 @@ def test_missing_child_link_name():
         UrdfTransformManager().load_urdf(urdf)
 
 
+def test_xml_namespace():
+    urdf = """
+    <robot name="robot_name" xmlns="http://www.ros.org">
+    <link name="link0"/>
+    <link name="link1">
+        <visual name="link1_visual">
+            <origin xyz="0 0 1"/>
+            <geometry/>
+        </visual>
+    </link>
+    <joint name="joint0" type="fixed">
+        <parent link="link0"/>
+        <child link="link1"/>
+        <origin xyz="0 1 0"/>
+    </joint>
+    </robot>
+    """
+
+    robot_name, links, joints = parse_urdf(urdf)
+
+    assert robot_name == 'robot_name'
+    assert len(links) == 2
+    assert len(joints) == 1
+
+    for link in links:
+        assert link.name in ['link0', 'link1']
+
+    assert joints[0].joint_name == 'joint0'
+
+
 def test_reference_to_unknown_child():
     urdf = """
     <robot name="robot_name">

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -4,6 +4,7 @@ See :doc:`user_guide/transform_manager` for more information.
 """
 
 import os
+import re
 import warnings
 
 import numpy as np
@@ -412,6 +413,13 @@ def parse_urdf(urdf_xml, mesh_path=None, package_dir=None, strict_check=True):
     # URDF XML schema:
     # https://github.com/ros/urdfdom/blob/master/xsd/urdf.xsd
 
+    # If there is an XML namespace (xmlns=...) specified, this will break parsing as
+    # the root tag, and the tag of all elements underneath root, will have a {namespace}
+    # prefix. As such, normalize the namespace to the default (i.e. no namespace).
+
+    _normalize_namespace(root)
+
+
     if root.tag != "robot":
         raise UrdfException("Robot tag is missing.")
 
@@ -745,6 +753,15 @@ def _add_joints(tm, joints):
                 (0.0, 0.0),
                 "fixed",
             )
+
+def _normalize_namespace(root):
+    """Normalizes the namespace of the root node and all elements underneath it.
+    """
+
+    root.tag = re.sub(r"\{.*?\}", "", root.tag)
+
+    for element in root.iter():
+        element.tag = re.sub(r"\{.*?\}", "", element.tag)
 
 
 class Link(object):


### PR DESCRIPTION
The current parser does not properly handle URDF files which contain an `xmlns` (XML namespace) attribute. This is largely to do with the underlying XML parser which successfully parses the tree but prepends the tag/name for all elements (incl root) with `{namespace}`. This breaks the assumptions made about the root tag and causes the parser to raise an exception.

Additionally, further nodes will not parse correctly with this namespace tag.

To resolve this:

1. Add a normalization step which traverses the graph and strips the namespace prefix from all elements
2. Adds a test with an example XML string.

It was surprising to me that the parser fails when it is particularly common to see URDF files with a namespace (most commonly from ROS). I am not sure of a better/cleaner way, but a simple normalization (i.e. removal of the namespace prefix) seems logical.

Tested with Python 3.12 on Windows. The test suite passes successfully.