### PR TITLE
[MRG] Viser visualization backend

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,7 @@ omit =
     pytransform3d/plot_utils/*.py
     pytransform3d/editor.py
     pytransform3d/visualizer/*.py
+    pytransform3d/viser/*.py
     pytransform3d/*/_plot.py
     pytransform3d/test/*.py
     pytransform3d/*/test/*.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,25 @@ command will be:
 (If any of the above seems like magic to you, then look up the
 [Git documentation](http://git-scm.com/documentation) on the web.)
 
+## Building the Documentation
+
+Install the documentation dependencies and a headless Chromium browser (used
+to render viser gallery images):
+
+```bash
+pip install -e .[doc]
+playwright install chromium
+```
+
+Then build the HTML docs from the `doc/` directory:
+
+```bash
+cd doc
+make html
+```
+
+The built documentation will be in `doc/build/html/`.
+
 ## Requirements for New Features
 
 Adding a new feature to pytransform3d requires a few other changes:

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -787,3 +787,39 @@ Dual Quaternions
    ~Plane
    ~Graph
    ~Camera
+
+
+:mod:`pytransform3d.viser`
+==========================
+
+.. automodule:: pytransform3d.viser
+    :no-members:
+    :no-inherited-members:
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~figure
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: class.rst
+
+   ~Figure
+   ~Artist
+   ~Line3D
+   ~PointCollection3D
+   ~Vector3D
+   ~Frame
+   ~Trajectory
+   ~Sphere
+   ~Box
+   ~Cylinder
+   ~Mesh
+   ~Ellipsoid
+   ~Capsule
+   ~Cone
+   ~Plane
+   ~Graph
+   ~Camera

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -125,6 +125,55 @@ class Open3DScraper:
         return figure_rst(image_names, gallery_conf["src_dir"])
 
 
+class ViserScraper:
+    def __repr__(self):
+        return f"<{type(self).__name__} object>"
+
+    def __call__(self, block, block_vars, gallery_conf, **kwargs):
+        """Scrape viser images saved by Figure.save_image().
+
+        Parameters
+        ----------
+        block : tuple
+            A tuple containing the (label, content, line_number) of the block.
+        block_vars : dict
+            Dict of block variables.
+        gallery_conf : dict
+            Contains the configuration of Sphinx-Gallery
+        **kwargs : dict
+            Additional keyword arguments (unused).
+
+        Returns
+        -------
+        rst : str
+            The ReSTructuredText that will be rendered to HTML containing
+            the images.
+        """
+        path_current_example = os.path.dirname(block_vars['src_file'])
+        imgs = sorted(glob.glob(os.path.join(
+            path_current_example, "__viser_rendered_image.jpg")))
+
+        image_names = list()
+        image_path_iterator = block_vars["image_path_iterator"]
+        for img in imgs:
+            this_image_path = image_path_iterator.next()
+            image_names.append(this_image_path)
+            shutil.move(img, this_image_path)
+        return figure_rst(image_names, gallery_conf["src_dir"])
+
+
+class CombinedScraper:
+    """Handles both Open3D and viser rendered images."""
+
+    def __repr__(self):
+        return f"<{type(self).__name__} object>"
+
+    def __call__(self, block, block_vars, gallery_conf, **kwargs):
+        rst = Open3DScraper()(block, block_vars, gallery_conf, **kwargs)
+        rst += ViserScraper()(block, block_vars, gallery_conf, **kwargs)
+        return rst
+
+
 def _get_sg_image_scraper():
     """Return the callable scraper to be used by Sphinx-Gallery.
 
@@ -139,7 +188,7 @@ def _get_sg_image_scraper():
 
     .. _sphinx-gallery/sphinx-gallery/494: https://github.com/sphinx-gallery/sphinx-gallery/pull/494
     """
-    return Open3DScraper()
+    return CombinedScraper()
 
 
 # monkeypatching pytransform3d to make the config pickable

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -24,10 +24,13 @@ Optional Dependencies
 When using pip, you can install pytransform3d with the options all, doc, and
 test.
 
-* `all` will add support for loading meshes, the 3D visualizer of
-  pytransform3d, and pydot export of `TransformManager` objects.
-* `doc` will install necessary dependencies to build this documentation.
-* `test` will install dependencies to run the unit tests.
+* ``all`` will add support for loading meshes, the Open3D and viser 3D
+  visualizers, and pydot export of ``TransformManager`` objects.
+* ``doc`` will install the dependencies needed to build this documentation,
+  including the viser gallery examples. After installing, also run
+  ``playwright install chromium`` to download the headless browser used to
+  render viser screenshots.
+* ``test`` will install dependencies to run the unit tests.
 
 For example, you can call
 
@@ -59,7 +62,7 @@ Install the package with:
 
 .. code-block:: bash
 
-    python setup.py install
+    pip install -e .
 
 pip also supports installation from a git repository:
 

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -16,3 +16,4 @@ User Guide
    transformation_over_time
    uncertainty
    camera
+   viser

--- a/doc/source/user_guide/transform_manager.rst
+++ b/doc/source/user_guide/transform_manager.rst
@@ -51,8 +51,8 @@ files. The library `trimesh <https://trimsh.org/>`_ will be used to load
 meshes. Here is a simple example with one visual that is used for two links:
 :ref:`sphx_glr__auto_examples_plots_plot_urdf_with_meshes.py`.
 
-Note that we can use Matplotlib or Open3D to visualize URDFs or any graph of
-transformations. In previous versions of this library, an example using
+Note that we can use Matplotlib, Open3D, or viser to visualize URDFs or any
+graph of transformations. In previous versions of this library, an example using
 pyrender was also included. This has been removed, as there is now another
 software package that does this:
 `urdf_viz <https://github.com/IRP-TU-BS/urdf_viz>`_. urdf_viz uses

--- a/doc/source/user_guide/viser.rst
+++ b/doc/source/user_guide/viser.rst
@@ -132,5 +132,18 @@ all connected browsers automatically:
 
     fig.animate(update, n_frames, loop=True, fargs=(frame,))
 
-See also the examples in ``examples/visualizations/`` for more complete
-animation examples.
+--------
+Examples
+--------
+
+The gallery contains four viser examples that cover a range of use cases:
+
+* :ref:`sphx_glr__auto_examples_viser_vis_viser_shapes.py` -- all geometric
+  primitives in a single static scene.
+* :ref:`sphx_glr__auto_examples_viser_vis_viser_robot_arm.py` -- animated
+  6-DOF robot arm with real-time TCP trajectory tracing.
+* :ref:`sphx_glr__auto_examples_viser_vis_viser_wrench_dynamics.py` --
+  rigid-body simulation driven by a body-fixed wrench, with a rolling
+  position trail.
+* :ref:`sphx_glr__auto_examples_viser_vis_viser_camera_orbit.py` -- pinhole
+  camera orbiting a static scene, showing the frustum at each pose.

--- a/doc/source/user_guide/viser.rst
+++ b/doc/source/user_guide/viser.rst
@@ -84,10 +84,11 @@ The two backends behave identically except for the following points:
   :func:`~pytransform3d.viser.Figure.show` returns immediately after printing
   the URL; the Open3D version blocks until the window is closed.
 
-* **save_image() is not supported.** The viser backend raises
-  :class:`NotImplementedError` when
-  :func:`~pytransform3d.viser.Figure.save_image` is called. Use your
-  browser's screenshot function instead.
+* **save_image() requires playwright.** The viser backend renders the scene
+  in a headless Chromium browser to produce the image. Install the extra
+  dependencies with ``pip install playwright imageio`` and then run
+  ``playwright install chromium`` before calling
+  :func:`~pytransform3d.viser.Figure.save_image`.
 
 * **set_line_width() has no effect.** viser does not expose a line-width
   setting after the scene is created. The method issues a
@@ -136,7 +137,7 @@ all connected browsers automatically:
 Examples
 --------
 
-The gallery contains five viser examples that cover a range of use cases:
+The gallery contains six viser examples that cover a range of use cases:
 
 * :ref:`sphx_glr__auto_examples_viser_vis_viser_shapes.py` -- all geometric
   primitives in a single static scene.

--- a/doc/source/user_guide/viser.rst
+++ b/doc/source/user_guide/viser.rst
@@ -1,0 +1,136 @@
+============================
+Viser Visualization Backend
+============================
+
+pytransform3d ships with two 3D visualization backends. The default one,
+:mod:`pytransform3d.visualizer`, is backed by
+`Open3D <http://www.open3d.org/>`_ and opens a native desktop window. The
+second backend, :mod:`pytransform3d.viser`, is backed by
+`viser <https://viser.studio/>`_ and renders in a web browser. Because the
+viser server runs over a WebSocket, the viser backend works in headless
+environments (remote servers, containers, notebooks) where a display is not
+available.
+
+Both backends share the same public API, so switching between them is a
+one-line change.
+
+------------
+Installation
+------------
+
+viser is an optional dependency. Install it together with the other optional
+packages using:
+
+.. code-block:: bash
+
+    python -m pip install 'pytransform3d[all]'
+
+or install viser on its own:
+
+.. code-block:: bash
+
+    python -m pip install viser
+
+`trimesh <https://trimsh.org/>`_ is required for shapes that have no native
+viser primitive (cylinders, cones, capsules, ellipsoids, and vectors). It is
+included in the ``all`` extras group.
+
+-----------
+Basic Usage
+-----------
+
+Replace the import of :mod:`pytransform3d.visualizer` with
+:mod:`pytransform3d.viser`. Everything else stays the same:
+
+.. code-block:: python
+
+    import numpy as np
+    import pytransform3d.viser as pv
+    from pytransform3d.transformations import random_transform
+
+    rng = np.random.default_rng(0)
+
+    fig = pv.figure()
+    fig.plot_transform(A2B=random_transform(rng))
+    fig.plot_sphere(radius=0.3, A2B=np.eye(4), c=(0.2, 0.6, 1.0))
+    fig.show()
+
+Calling :func:`~pytransform3d.viser.Figure.show` prints the URL of the viser
+server to the console and returns immediately. Open the printed URL in a
+browser to view the scene. The server keeps running until the Python process
+exits or until you call ``fig._server.stop()``.
+
+Open3D's :func:`~pytransform3d.visualizer.Figure.show` blocks until the
+window is closed; the viser :func:`~pytransform3d.viser.Figure.show` does not.
+If you need the script to wait for user interaction you can add a blocking
+call after ``fig.show()``:
+
+.. code-block:: python
+
+    fig.show()
+    input("Press Enter to exit...")
+
+-----------
+Differences
+-----------
+
+The two backends behave identically except for the following points:
+
+* **Window vs browser.** Open3D opens a native window; viser opens a browser
+  tab. After calling :func:`~pytransform3d.viser.Figure.show`, navigate to
+  the printed URL (typically ``http://localhost:8080``).
+
+* **show() is non-blocking.** The viser
+  :func:`~pytransform3d.viser.Figure.show` returns immediately after printing
+  the URL; the Open3D version blocks until the window is closed.
+
+* **save_image() is not supported.** The viser backend raises
+  :class:`NotImplementedError` when
+  :func:`~pytransform3d.viser.Figure.save_image` is called. Use your
+  browser's screenshot function instead.
+
+* **set_line_width() has no effect.** viser does not expose a line-width
+  setting after the scene is created. The method issues a
+  :class:`UserWarning` and returns without error.
+
+* **port.** The default port is ``8080``. Pass a different port to
+  :func:`~pytransform3d.viser.figure` if that port is already in use:
+
+  .. code-block:: python
+
+      fig = pv.figure(port=9090)
+
+---------
+Animation
+---------
+
+:func:`~pytransform3d.viser.Figure.animate` works the same way as in the
+Open3D backend. The callback receives the frame index and any extra arguments
+and should return a list of artists. The viser server pushes each frame to
+all connected browsers automatically:
+
+.. code-block:: python
+
+    import numpy as np
+    import pytransform3d.viser as pv
+    from pytransform3d.transformations import transform_from
+    from pytransform3d.rotations import matrix_from_axis_angle
+
+    fig = pv.figure()
+    frame = fig.plot_transform()
+    fig.show()
+
+    n_frames = 60
+
+    def update(step, frame):
+        angle = 2.0 * np.pi * step / n_frames
+        A2B = transform_from(
+            R=matrix_from_axis_angle([0, 0, 1, angle]), p=np.zeros(3)
+        )
+        frame.set_data(A2B)
+        return [frame]
+
+    fig.animate(update, n_frames, loop=True, fargs=(frame,))
+
+See also the examples in ``examples/visualizations/`` for more complete
+animation examples.

--- a/doc/source/user_guide/viser.rst
+++ b/doc/source/user_guide/viser.rst
@@ -136,7 +136,7 @@ all connected browsers automatically:
 Examples
 --------
 
-The gallery contains four viser examples that cover a range of use cases:
+The gallery contains five viser examples that cover a range of use cases:
 
 * :ref:`sphx_glr__auto_examples_viser_vis_viser_shapes.py` -- all geometric
   primitives in a single static scene.
@@ -151,3 +151,6 @@ The gallery contains four viser examples that cover a range of use cases:
   banana distribution from concatenating uncertain transforms: MC-sampled
   paths, mean trajectory, projected SE(3) hyperellipsoid, and position
   ellipsoid.
+* :ref:`sphx_glr__auto_examples_viser_vis_viser_probabilistic_robot_kinematics.py`
+  -- animated 6-DOF robot with the PPOE end-effector pose uncertainty
+  ellipsoid updating in real time.

--- a/doc/source/user_guide/viser.rst
+++ b/doc/source/user_guide/viser.rst
@@ -147,3 +147,7 @@ The gallery contains four viser examples that cover a range of use cases:
   position trail.
 * :ref:`sphx_glr__auto_examples_viser_vis_viser_camera_orbit.py` -- pinhole
   camera orbiting a static scene, showing the frustum at each pose.
+* :ref:`sphx_glr__auto_examples_viser_vis_viser_uncertain_transforms.py` --
+  banana distribution from concatenating uncertain transforms: MC-sampled
+  paths, mean trajectory, projected SE(3) hyperellipsoid, and position
+  ellipsoid.

--- a/examples/viser/README.rst
+++ b/examples/viser/README.rst
@@ -1,0 +1,2 @@
+Viser Visualizations
+--------------------

--- a/examples/viser/vis_viser_camera_orbit.py
+++ b/examples/viser/vis_viser_camera_orbit.py
@@ -44,7 +44,7 @@ virtual_image_distance = 0.6
 
 fig = pv.figure()
 # Slightly above and to the side to see the full orbit arc.
-fig.view_init(azim=45, elev=25, distance=4.5)
+fig.view_init(azim=30, elev=35, distance=4.5)
 
 # World frame at the origin.
 fig.plot_transform(A2B=np.eye(4), s=0.4)

--- a/examples/viser/vis_viser_camera_orbit.py
+++ b/examples/viser/vis_viser_camera_orbit.py
@@ -43,25 +43,27 @@ virtual_image_distance = 0.6
 # ------------
 
 fig = pv.figure()
+# Slightly above and to the side to see the full orbit arc.
+fig.view_init(azim=45, elev=25, distance=4.5)
 
 # World frame at the origin.
 fig.plot_transform(A2B=np.eye(4), s=0.4)
 
-# A few objects to look at.
+# A few objects to look at.  Viser is y-up: [x, height, z].
 fig.plot_box(
-    size=[0.4, 0.6, 0.3],
-    A2B=transform_from(np.eye(3), [0.3, 0.0, 0.15]),
+    size=[0.4, 0.3, 0.6],
+    A2B=transform_from(np.eye(3), [0.3, 0.15, 0.0]),
     c=(0.7, 0.3, 0.2),
 )
 fig.plot_sphere(
     radius=0.18,
-    A2B=transform_from(np.eye(3), [-0.35, 0.25, 0.18]),
+    A2B=transform_from(np.eye(3), [-0.35, 0.18, 0.25]),
     c=(0.2, 0.6, 0.85),
 )
 fig.plot_cylinder(
     length=0.55,
     radius=0.09,
-    A2B=transform_from(np.eye(3), [0.0, -0.4, 0.275]),
+    A2B=transform_from(np.eye(3), [0.0, 0.275, -0.4]),
     c=(0.3, 0.75, 0.3),
 )
 
@@ -74,7 +76,8 @@ def look_at(position, target=np.zeros(3)):
     """Build a cam2world transform that places the camera at *position*
     with its optical axis pointing toward *target*.
 
-    The camera convention used here is z-forward, y-down.
+    The camera convention used here is z-forward, y-down.  Viser uses a
+    y-up world coordinate system, so world-up is +y.
 
     Parameters
     ----------
@@ -91,11 +94,10 @@ def look_at(position, target=np.zeros(3)):
     """
     z_cam = target - position  # forward
     z_cam /= np.linalg.norm(z_cam)
-    # Use global +Z as a guide for the up direction; fall back to +X if
-    # the camera is looking straight up or down.
-    world_up = np.array([0.0, 0.0, 1.0])
+    # Viser is y-up; fall back to +z when looking straight up or down.
+    world_up = np.array([0.0, 1.0, 0.0])
     if abs(np.dot(z_cam, world_up)) > 0.99:
-        world_up = np.array([1.0, 0.0, 0.0])
+        world_up = np.array([0.0, 0.0, 1.0])
     x_cam = np.cross(z_cam, world_up)
     x_cam /= np.linalg.norm(x_cam)
     y_cam = np.cross(z_cam, x_cam)
@@ -111,7 +113,7 @@ orbit_radius = 1.8
 orbit_height = 0.8
 n_frames = 120
 
-initial_cam2world = look_at(np.array([orbit_radius, 0.0, orbit_height]))
+initial_cam2world = look_at(np.array([orbit_radius, orbit_height, 0.0]))
 camera_artist = fig.plot_camera(
     M=M,
     cam2world=initial_cam2world,
@@ -150,8 +152,8 @@ def animation_callback(step, n_frames, camera_artist, camera_frame):
     pos = np.array(
         [
             orbit_radius * np.cos(angle),
-            orbit_radius * np.sin(angle),
             orbit_height,
+            orbit_radius * np.sin(angle),
         ]
     )
     cam2world = look_at(pos)
@@ -168,3 +170,5 @@ if "__file__" in globals():
         loop=True,
         fargs=(n_frames, camera_artist, camera_frame),
     )
+else:
+    fig.save_image("__viser_rendered_image.jpg")

--- a/examples/viser/vis_viser_camera_orbit.py
+++ b/examples/viser/vis_viser_camera_orbit.py
@@ -1,0 +1,170 @@
+"""
+======================
+Camera Orbiting Scene
+======================
+
+A pinhole camera is animated orbiting around a static scene. The camera
+frustum updates at each frame to show the camera's current position and
+field of view.
+
+The scene contains a coordinate frame at the origin, a box, a sphere, and
+a cylinder. The camera position is constrained to a circle at a fixed radius
+and height, always pointing toward the origin. The orbit plane is tilted
+slightly so the camera looks at the scene from above.
+
+Camera intrinsics
+-----------------
+The intrinsic matrix encodes the focal length and the principal point::
+
+    M = [[fx,  0, cx],
+         [ 0, fy, cy],
+         [ 0,  0,  1]]
+
+The visualized frustum shows the four rays from the camera centre through the
+image corners and a rectangle at ``virtual_image_distance`` from the camera.
+"""
+
+import numpy as np
+
+import pytransform3d.viser as pv
+from pytransform3d.transformations import transform_from
+
+# %%
+# Camera intrinsics
+# -----------------
+
+fl = 600.0  # focal length [pixels]
+w, h = 640, 480  # sensor size [pixels]
+M = np.array([[fl, 0, w / 2.0], [0, fl, h / 2.0], [0, 0, 1]], dtype=float)
+virtual_image_distance = 0.6
+
+# %%
+# Static scene
+# ------------
+
+fig = pv.figure()
+
+# World frame at the origin.
+fig.plot_transform(A2B=np.eye(4), s=0.4)
+
+# A few objects to look at.
+fig.plot_box(
+    size=[0.4, 0.6, 0.3],
+    A2B=transform_from(np.eye(3), [0.3, 0.0, 0.15]),
+    c=(0.7, 0.3, 0.2),
+)
+fig.plot_sphere(
+    radius=0.18,
+    A2B=transform_from(np.eye(3), [-0.35, 0.25, 0.18]),
+    c=(0.2, 0.6, 0.85),
+)
+fig.plot_cylinder(
+    length=0.55,
+    radius=0.09,
+    A2B=transform_from(np.eye(3), [0.0, -0.4, 0.275]),
+    c=(0.3, 0.75, 0.3),
+)
+
+# %%
+# Camera pose helper
+# ------------------
+
+
+def look_at(position, target=np.zeros(3)):
+    """Build a cam2world transform that places the camera at *position*
+    with its optical axis pointing toward *target*.
+
+    The camera convention used here is z-forward, y-down.
+
+    Parameters
+    ----------
+    position : array, shape (3,)
+        Camera position in world coordinates.
+
+    target : array, shape (3,)
+        Point the camera looks at.
+
+    Returns
+    -------
+    cam2world : array, shape (4, 4)
+        Transformation from camera frame to world frame.
+    """
+    z_cam = target - position  # forward
+    z_cam /= np.linalg.norm(z_cam)
+    # Use global +Z as a guide for the up direction; fall back to +X if
+    # the camera is looking straight up or down.
+    world_up = np.array([0.0, 0.0, 1.0])
+    if abs(np.dot(z_cam, world_up)) > 0.99:
+        world_up = np.array([1.0, 0.0, 0.0])
+    x_cam = np.cross(z_cam, world_up)
+    x_cam /= np.linalg.norm(x_cam)
+    y_cam = np.cross(z_cam, x_cam)
+    R = np.column_stack([x_cam, y_cam, z_cam])
+    return transform_from(R, position)
+
+
+# %%
+# Initial camera pose and artist
+# --------------------------------
+
+orbit_radius = 1.8
+orbit_height = 0.8
+n_frames = 120
+
+initial_cam2world = look_at(np.array([orbit_radius, 0.0, orbit_height]))
+camera_artist = fig.plot_camera(
+    M=M,
+    cam2world=initial_cam2world,
+    virtual_image_distance=virtual_image_distance,
+    sensor_size=(w, h),
+)
+# Show the camera's own coordinate frame.
+camera_frame = fig.plot_transform(A2B=initial_cam2world, s=0.18)
+
+
+# %%
+# Animation callback
+# ------------------
+
+
+def animation_callback(step, n_frames, camera_artist, camera_frame):
+    """Move the camera one step along its circular orbit.
+
+    Parameters
+    ----------
+    step : int
+        Current frame index.
+    n_frames : int
+        Total number of frames in one orbit.
+    camera_artist : Camera
+        Camera frustum artist.
+    camera_frame : Frame
+        Coordinate frame artist for the camera.
+
+    Returns
+    -------
+    artists : tuple
+        Updated artists.
+    """
+    angle = 2.0 * np.pi * step / n_frames
+    pos = np.array(
+        [
+            orbit_radius * np.cos(angle),
+            orbit_radius * np.sin(angle),
+            orbit_height,
+        ]
+    )
+    cam2world = look_at(pos)
+    camera_artist.set_data(cam2world=cam2world)
+    camera_frame.set_data(cam2world)
+    return camera_artist, camera_frame
+
+
+if "__file__" in globals():
+    fig.show()
+    fig.animate(
+        animation_callback,
+        n_frames,
+        loop=True,
+        fargs=(n_frames, camera_artist, camera_frame),
+    )

--- a/examples/viser/vis_viser_probabilistic_robot_kinematics.py
+++ b/examples/viser/vis_viser_probabilistic_robot_kinematics.py
@@ -384,6 +384,8 @@ if "__file__" in globals():
         fargs=(n_frames, tm, graph, joint_names, thetas, covs, surface),
     )
     input("Press Enter to exit...")
+else:
+    fig.save_image("__viser_rendered_image.jpg")
 
 # %%
 # References

--- a/examples/viser/vis_viser_probabilistic_robot_kinematics.py
+++ b/examples/viser/vis_viser_probabilistic_robot_kinematics.py
@@ -1,0 +1,396 @@
+"""
+=====================================
+Probabilistic Product of Exponentials
+=====================================
+
+We compute the probabilistic forward kinematics of a robot with flexible
+links or joints and visualize the projected equiprobably ellipsoid of the
+end-effector's pose distribution.
+"""
+
+import os
+
+import numpy as np
+
+import pytransform3d.trajectories as ptr
+import pytransform3d.transformations as pt
+import pytransform3d.uncertainty as pu
+import pytransform3d.viser as pv
+from pytransform3d.urdf import UrdfTransformManager
+
+
+# %%
+# Probabilistic Robot Kinematics
+# ------------------------------
+#
+# The end-effector's pose distribution is computed based on the Probabilistic
+# Product of Exponentials PPOE [1]_.
+#
+# Our ProbabilisticRobotKinematics class is a subclass of
+# :class:`~pytransform3d.urdf.UrdfTransformManager`, which loads a description
+# of a robot from the URDF format.
+#
+# The complicated part of this example is the conversion of kinematics
+# parameters from URDF data to screw axes that are needed for the product
+# of exponentials formulation of forward kinematics.
+#
+# Once we have this information, the implementation of the probabilistic
+# product of exponentials is straightforward:
+#
+# 1. We multiply the screw axis of each joint with the corresponding joint
+#    angle to obtain the exponential coordinates of each relative joint
+#    displacement.
+# 2. We concatenate the relative joint displacements and the base pose to
+#    obtain the end-effector's pose. This is the original product of
+#    exponentials.
+# 3. The PPOE modifies the original product of exponentials by transforming
+#    and concatenating the covariances of each transformation.
+class ProbabilisticRobotKinematics(UrdfTransformManager):
+    """Probabilistic robot kinematics.
+
+    Parameters
+    ----------
+    robot_urdf : str
+        URDF description of robot
+
+    ee_frame : str
+        Name of the end-effector frame
+
+    base_frame : str
+        Name of the base frame
+
+    joint_names : list
+        Names of joints in order from base to end effector
+
+    mesh_path : str, optional (default: None)
+        Path in which we search for meshes that are defined in the URDF.
+        Meshes will be ignored if it is set to None and no 'package_dir'
+        is given.
+
+    package_dir : str, optional (default: None)
+        Some URDFs start file names with 'package://' to refer to the ROS
+        package in which these files (textures, meshes) are located. This
+        variable defines to which path this prefix will be resolved.
+    """
+
+    def __init__(
+        self,
+        robot_urdf,
+        ee_frame,
+        base_frame,
+        joint_names,
+        mesh_path=None,
+        package_dir=None,
+    ):
+        super(ProbabilisticRobotKinematics, self).__init__(check=False)
+        self.load_urdf(robot_urdf, mesh_path=mesh_path, package_dir=package_dir)
+        self.ee2base_home, self.screw_axes_home = self._get_screw_axes(
+            ee_frame, base_frame, joint_names
+        )
+        self.joint_limits = np.array(
+            [self.get_joint_limits(jn) for jn in joint_names]
+        )
+
+    def _get_screw_axes(self, ee_frame, base_frame, joint_names):
+        """Get screw axes of joints in space frame at robot's home position.
+
+        Parameters
+        ----------
+        ee_frame : str
+            Name of the end-effector frame
+
+        base_frame : str
+            Name of the base frame
+
+        joint_names : list
+            Names of joints in order from base to end effector
+
+        Returns
+        -------
+        ee2base_home : array, shape (4, 4)
+            The home configuration (position and orientation) of the
+            end-effector.
+
+        screw_axes_home : array, shape (n_joints, 6)
+            The joint screw axes in the space frame when the manipulator is at
+            the home position.
+        """
+        ee2base_home = self.get_transform(ee_frame, base_frame)
+        screw_axes_home = []
+        for jn in joint_names:
+            ln, _, _, s_axis, limits, joint_type = self._joints[jn]
+            link2base = self.get_transform(ln, base_frame)
+            s_axis = np.dot(link2base[:3, :3], s_axis)
+            q = link2base[:3, 3]
+
+            if joint_type == "revolute":
+                h = 0.0
+            elif joint_type == "prismatic":
+                h = np.inf
+            else:
+                raise NotImplementedError(
+                    "Joint type %s not supported." % joint_type
+                )
+
+            screw_axis = pt.screw_axis_from_screw_parameters(q, s_axis, h)
+            screw_axes_home.append(screw_axis)
+        screw_axes_home = np.row_stack(screw_axes_home)
+        return ee2base_home, screw_axes_home
+
+    def probabilistic_forward_kinematics(self, thetas, covs):
+        """Compute probabilistic forward kinematics.
+
+        This is based on the probabilistic product of exponentials.
+
+        Parameters
+        ----------
+        thetas : array, shape (n_joints,)
+            A list of joint coordinates.
+
+        covs : array, shape (n_joints, 6, 6)
+            Covariances of joint transformations.
+
+        Returns
+        -------
+        ee2base : array, shape (4, 4)
+            A homogeneous transformation matrix representing the end-effector
+            frame when the joints are at the specified coordinates.
+
+        cov : array, shape (6, 6)
+            Covariance of the pose in tangent space.
+        """
+        assert len(thetas) == self.screw_axes_home.shape[0]
+        thetas = np.clip(
+            thetas, self.joint_limits[:, 0], self.joint_limits[:, 1]
+        )
+
+        Sthetas = self.screw_axes_home * thetas[:, np.newaxis]
+        joint_displacements = ptr.transforms_from_exponential_coordinates(
+            Sthetas
+        )
+
+        T = np.eye(4)
+        cov = np.zeros((6, 6))
+        for i in range(len(thetas)):
+            T, cov = pu.concat_locally_uncertain_transforms(
+                joint_displacements[i], T, covs[i], cov
+            )
+
+        T = T.dot(self.ee2base_home)
+        ad = pt.adjoint_from_transform(self.ee2base_home)
+        cov = ad.dot(cov).dot(ad.T)
+
+        return T, cov
+
+
+# %%
+# Surface helper
+# --------------
+# To visualize the 6D covariance in the tangent space of SE(3), we project its
+# equiprobable hyper-ellipsoid to 3D and represent it as a mesh.
+
+
+def grid_to_mesh(x, y, z):
+    """Triangulate a surface defined by grid arrays.
+
+    Parameters
+    ----------
+    x : array, shape (m, n)
+        x-coordinates of the surface grid.
+
+    y : array, shape (m, n)
+        y-coordinates of the surface grid.
+
+    z : array, shape (m, n)
+        z-coordinates of the surface grid.
+
+    Returns
+    -------
+    vertices : array, shape (m*n, 3)
+        Vertex positions.
+
+    faces : array, shape ((m-1)*(n-1)*2, 3)
+        Triangle face indices.
+    """
+    m, n = x.shape
+    vertices = np.column_stack([x.ravel(), y.ravel(), z.ravel()]).astype(
+        np.float32
+    )
+    triangles = []
+    for i in range(m - 1):
+        for j in range(n - 1):
+            v00 = i * n + j
+            v10 = (i + 1) * n + j
+            v11 = (i + 1) * n + j + 1
+            v01 = i * n + j + 1
+            triangles.extend([[v00, v10, v11], [v00, v11, v01]])
+    return vertices, np.array(triangles, dtype=np.int32)
+
+
+class Surface:
+    """Surface mesh to be visualized with viser.
+
+    Parameters
+    ----------
+    scene : viser scene handle
+        The viser scene to add the mesh to.
+
+    name : str
+        Base name for the mesh objects in the viser scene.
+
+    x : array, shape (n_steps, n_steps)
+        Coordinates on x-axis of grid on surface.
+
+    y : array, shape (n_steps, n_steps)
+        Coordinates on y-axis of grid on surface.
+
+    z : array, shape (n_steps, n_steps)
+        Coordinates on z-axis of grid on surface.
+
+    c : array-like, shape (3,), optional (default: None)
+        RGB color in [0, 1] range.
+    """
+
+    def __init__(self, scene, name, x, y, z, c=None):
+        self._scene = scene
+        self._name = name
+        if c is not None:
+            arr = np.asarray(c, dtype=float)
+            self._color = tuple(int(np.clip(v * 255, 0, 255)) for v in arr[:3])
+        else:
+            self._color = (0, 128, 128)
+        self.set_data(x, y, z)
+
+    def set_data(self, x, y, z):
+        """Update the surface mesh.
+
+        Parameters
+        ----------
+        x : array, shape (n_steps, n_steps)
+            Coordinates on x-axis of grid on surface.
+
+        y : array, shape (n_steps, n_steps)
+            Coordinates on y-axis of grid on surface.
+
+        z : array, shape (n_steps, n_steps)
+            Coordinates on z-axis of grid on surface.
+        """
+        vertices, faces = grid_to_mesh(x, y, z)
+        self._scene.add_mesh_simple(
+            name=self._name + "/solid",
+            vertices=vertices,
+            faces=faces,
+            color=self._color,
+            opacity=0.5,
+            side="double",
+        )
+        self._scene.add_mesh_simple(
+            name=self._name + "/wire",
+            vertices=vertices,
+            faces=faces,
+            color=self._color,
+            wireframe=True,
+            side="double",
+        )
+
+
+# %%
+# Animation callback
+# ------------------
+# Each frame updates the joint angles and recomputes the end-effector pose
+# distribution, then refreshes both the robot graph and the ellipsoid mesh.
+def animation_callback(
+    step, n_frames, tm, graph, joint_names, thetas, covs, surface
+):
+    angle = 0.5 * np.cos(2.0 * np.pi * (0.5 + step / n_frames))
+    thetas_t = angle * thetas
+    for joint_name, value in zip(joint_names, thetas_t):
+        tm.set_joint(joint_name, value)
+    graph.set_data()
+
+    T, cov = tm.probabilistic_forward_kinematics(thetas_t, covs)
+    x, y, z = pu.to_projected_ellipsoid(T, cov, factor=1, n_steps=50)
+    surface.set_data(x, y, z)
+
+    return graph, surface
+
+
+# %%
+# Setup
+# -----
+# We load the URDF file,
+BASE_DIR = "test/test_data/"
+data_dir = BASE_DIR
+search_path = "."
+while (
+    not os.path.exists(data_dir)
+    and os.path.dirname(search_path) != "pytransform3d"
+):
+    search_path = os.path.join(search_path, "..")
+    data_dir = os.path.join(search_path, BASE_DIR)
+filename = os.path.join(data_dir, "robot_with_visuals.urdf")
+with open(filename, "r") as f:
+    robot_urdf = f.read()
+
+# %%
+# define the kinematic chain that we are interested in,
+joint_names = ["joint%d" % i for i in range(1, 7)]
+tm = ProbabilisticRobotKinematics(
+    robot_urdf, "tcp", "linkmount", joint_names, mesh_path=data_dir
+)
+
+# %%
+# define the joint angles,
+thetas = np.array([1, 1, 1, 0, 1, 0])
+current_thetas = -0.5 * thetas
+for joint_name, theta in zip(joint_names, current_thetas):
+    tm.set_joint(joint_name, theta)
+
+# %%
+# and define the covariances of the joints.
+covs = np.zeros((len(thetas), 6, 6))
+covs[0] = np.diag([0, 0, 1, 0, 0, 0])
+covs[1] = np.diag([0, 1, 0, 0, 0, 0])
+covs[2] = np.diag([0, 1, 0, 0, 0, 0])
+covs[4] = np.diag([0, 1, 0, 0, 0, 0])
+covs *= 0.05
+
+# %%
+# PPOE and Visualization
+# ----------------------
+#
+# Then we can finally use PPOE to compute the end-effector pose and its
+# covariance.
+T, cov = tm.probabilistic_forward_kinematics(current_thetas, covs)
+
+# %%
+# We compute the 3D projection of the 6D covariance matrix.
+x, y, z = pu.to_projected_ellipsoid(T, cov, factor=1, n_steps=50)
+
+# %%
+# The following code sets up and animates the visualization.
+fig = pv.figure()
+graph = fig.plot_graph(tm, "robot_arm", show_visuals=True)
+fig.plot_transform(np.eye(4), s=0.3)
+surface = Surface(fig.scene, "/ee_ellipsoid", x, y, z, c=(0, 0.5, 0.5))
+fig.view_init(elev=20, azim=0)
+n_frames = 200
+if "__file__" in globals():
+    fig.show()
+    fig.animate(
+        animation_callback,
+        n_frames,
+        loop=True,
+        fargs=(n_frames, tm, graph, joint_names, thetas, covs, surface),
+    )
+    input("Press Enter to exit...")
+
+# %%
+# References
+# ----------
+#
+# .. [1] Meyer, Strobl, Triebel (2022): The Probabilistic Robot Kinematics
+#    Model and its Application to Sensor Fusion. In IEEE/RSJ International
+#    Conference on Intelligent Robots and Systems (IROS), Kyoto, Japan, 2022,
+#    pp. 3263-3270, doi: 10.1109/IROS47612.2022.9981399.
+#    https://elib.dlr.de/191928/1/202212_ELIB_PAPER_VERSION_with_copyright.pdf

--- a/examples/viser/vis_viser_probabilistic_robot_kinematics.py
+++ b/examples/viser/vis_viser_probabilistic_robot_kinematics.py
@@ -373,7 +373,7 @@ fig = pv.figure()
 graph = fig.plot_graph(tm, "robot_arm", show_visuals=True)
 fig.plot_transform(np.eye(4), s=0.3)
 surface = Surface(fig.scene, "/ee_ellipsoid", x, y, z, c=(0, 0.5, 0.5))
-fig.view_init(elev=20, azim=0)
+fig.view_init(elev=30, azim=30)
 n_frames = 200
 if "__file__" in globals():
     fig.show()

--- a/examples/viser/vis_viser_robot_arm.py
+++ b/examples/viser/vis_viser_robot_arm.py
@@ -1,0 +1,130 @@
+"""
+====================================
+Animated Robot with TCP Trajectory
+====================================
+
+A 6-DOF robot arm is animated while the trajectory of its tool-centre point
+(TCP) is traced in real time. Each joint follows an independent sinusoidal
+profile, producing a complex end-effector path.
+
+The TCP path drawn so far is shown as an orange line. After one full cycle the
+line resets and a new cycle begins.
+
+This example must be run from within the ``examples/`` folder or the main
+repository folder because it uses a relative path to the URDF file.
+"""
+
+import os
+
+import numpy as np
+
+import pytransform3d.viser as pv
+from pytransform3d.urdf import UrdfTransformManager
+
+# %%
+# Data loading
+# ------------
+
+BASE_DIR = "test/test_data/"
+data_dir = BASE_DIR
+search_path = "."
+while (
+    not os.path.exists(data_dir)
+    and os.path.dirname(search_path) != "pytransform3d"
+):
+    search_path = os.path.join(search_path, "..")
+    data_dir = os.path.join(search_path, BASE_DIR)
+
+tm = UrdfTransformManager()
+filename = os.path.join(data_dir, "robot_with_visuals.urdf")
+with open(filename, "r") as f:
+    tm.load_urdf(f.read(), mesh_path=data_dir)
+
+joint_names = ["joint%d" % i for i in range(1, 7)]
+# Independent phase offsets give a more varied TCP path.
+phases = np.linspace(0, np.pi, len(joint_names))
+n_frames = 150
+
+# %%
+# Pre-compute the full TCP trajectory so we can draw it incrementally.
+tcp_path = []
+for step in range(n_frames):
+    for i, joint_name in enumerate(joint_names):
+        angle = 0.5 * np.cos(2.0 * np.pi * step / n_frames + phases[i])
+        tm.set_joint(joint_name, angle)
+    tcp_path.append(tm.get_transform("tcp", "robot_arm")[:3, 3].copy())
+tcp_path = np.array(tcp_path)  # shape (n_frames, 3)
+
+# Reset joints to initial pose.
+for joint_name in joint_names:
+    tm.set_joint(joint_name, 0.0)
+
+# %%
+# Scene setup
+# -----------
+fig = pv.figure()
+graph = fig.plot_graph(
+    tm, "robot_arm", s=0.05, show_frames=True, show_visuals=True
+)
+
+# Initialize the trajectory line with a degenerate two-point segment so the
+# artist has a valid handle from the start.
+init_pos = tcp_path[0]
+trajectory_line = pv.Line3D(
+    P=np.vstack([init_pos, init_pos]),
+    c=(1.0, 0.5, 0.0),
+)
+trajectory_line.add_artist(fig)
+
+
+# %%
+# Animation callback
+# ------------------
+def animation_callback(
+    step, n_frames, tm, graph, trajectory_line, tcp_path, phases
+):
+    """Update robot pose and extend the TCP trajectory line.
+
+    Parameters
+    ----------
+    step : int
+        Current frame index.
+    n_frames : int
+        Total number of frames in one cycle.
+    tm : UrdfTransformManager
+        Robot kinematics manager.
+    graph : Graph
+        Artist representing the robot in the scene.
+    trajectory_line : Line3D
+        Artist for the TCP trajectory.
+    tcp_path : array, shape (n_frames, 3)
+        Pre-computed TCP positions.
+    phases : array, shape (n_joints,)
+        Phase offsets for each joint.
+
+    Returns
+    -------
+    artists : tuple
+        Updated artists.
+    """
+    for i, joint_name in enumerate(joint_names):
+        angle = 0.5 * np.cos(2.0 * np.pi * step / n_frames + phases[i])
+        tm.set_joint(joint_name, angle)
+    graph.set_data()
+
+    # Build path from start of cycle to current step.
+    # Always pass at least 2 points to keep the handle alive.
+    n_pts = max(2, step + 1)
+    trajectory_line.set_data(tcp_path[:n_pts])
+
+    return graph, trajectory_line
+
+
+if "__file__" in globals():
+    fig.show()
+    fig.animate(
+        animation_callback,
+        n_frames,
+        loop=True,
+        fargs=(n_frames, tm, graph, trajectory_line, tcp_path, phases),
+    )

--- a/examples/viser/vis_viser_robot_arm.py
+++ b/examples/viser/vis_viser_robot_arm.py
@@ -63,7 +63,7 @@ for joint_name in joint_names:
 # Scene setup
 # -----------
 fig = pv.figure()
-fig.view_init(azim=30, elev=20, center=(0.0, 0.3, 0.0), distance=2.5)
+fig.view_init(azim=30, elev=35, center=(0.0, 0.3, 0.0), distance=2.5)
 graph = fig.plot_graph(
     tm, "robot_arm", s=0.05, show_frames=True, show_visuals=True
 )

--- a/examples/viser/vis_viser_robot_arm.py
+++ b/examples/viser/vis_viser_robot_arm.py
@@ -63,6 +63,7 @@ for joint_name in joint_names:
 # Scene setup
 # -----------
 fig = pv.figure()
+fig.view_init(azim=30, elev=20, center=(0.0, 0.3, 0.0), distance=2.5)
 graph = fig.plot_graph(
     tm, "robot_arm", s=0.05, show_frames=True, show_visuals=True
 )
@@ -128,3 +129,5 @@ if "__file__" in globals():
         loop=True,
         fargs=(n_frames, tm, graph, trajectory_line, tcp_path, phases),
     )
+else:
+    fig.save_image("__viser_rendered_image.jpg")

--- a/examples/viser/vis_viser_shapes.py
+++ b/examples/viser/vis_viser_shapes.py
@@ -1,0 +1,102 @@
+"""
+====================
+Geometric Primitives
+====================
+
+All geometric primitive shapes supported by the viser backend are arranged
+in two rows. The first row shows sphere, box, cylinder, and capsule. The
+second row shows cone, ellipsoid, plane, and a camera frustum. Each shape is
+accompanied by a small coordinate frame at its origin.
+
+This example can be used as a reference for the available shapes and their
+constructor arguments.
+"""
+
+import numpy as np
+
+import pytransform3d.viser as pv
+from pytransform3d.transformations import transform_from
+
+fig = pv.figure()
+
+spacing_x = 1.8
+spacing_y = 2.0
+
+# %%
+# Row 0: sphere, box, cylinder, capsule
+# --------------------------------------
+
+p = np.array([0 * spacing_x, 0.0, 0.0])
+fig.plot_sphere(radius=0.4, A2B=transform_from(np.eye(3), p), c=(0.8, 0.2, 0.2))
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+p = np.array([1 * spacing_x, 0.0, 0.0])
+fig.plot_box(
+    size=[0.5, 0.7, 0.45], A2B=transform_from(np.eye(3), p), c=(0.2, 0.75, 0.2)
+)
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+p = np.array([2 * spacing_x, 0.0, 0.0])
+fig.plot_cylinder(
+    length=0.7,
+    radius=0.25,
+    A2B=transform_from(np.eye(3), p),
+    c=(0.2, 0.2, 0.85),
+)
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+p = np.array([3 * spacing_x, 0.0, 0.0])
+fig.plot_capsule(
+    height=0.45,
+    radius=0.25,
+    A2B=transform_from(np.eye(3), p),
+    c=(0.8, 0.8, 0.15),
+)
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+# %%
+# Row 1: cone, ellipsoid, plane, camera frustum
+# -----------------------------------------------
+
+p = np.array([0 * spacing_x, spacing_y, 0.0])
+fig.plot_cone(
+    height=0.7, radius=0.3, A2B=transform_from(np.eye(3), p), c=(0.85, 0.4, 0.1)
+)
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+p = np.array([1 * spacing_x, spacing_y, 0.0])
+fig.plot_ellipsoid(
+    radii=[0.5, 0.28, 0.18],
+    A2B=transform_from(np.eye(3), p),
+    c=(0.55, 0.1, 0.85),
+)
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+p = np.array([2 * spacing_x, spacing_y, 0.0])
+fig.plot_plane(normal=[0, 0, 1], point_in_plane=p, s=0.6, c=(0.1, 0.75, 0.75))
+fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
+
+# %%
+# Camera frustum: a pinhole camera tilted slightly downward.
+# M is the intrinsic matrix for a 640x480 image at focal length 500 px.
+fl = 500.0
+w, h = 640, 480
+M = np.array([[fl, 0, w / 2.0], [0, fl, h / 2.0], [0, 0, 1]], dtype=float)
+# Tilt the camera 30 degrees downward so the frustum is easy to see.
+tilt = np.pi / 6.0
+R_tilt = np.array(
+    [
+        [1, 0, 0],
+        [0, np.cos(tilt), -np.sin(tilt)],
+        [0, np.sin(tilt), np.cos(tilt)],
+    ]
+)
+cam2world = transform_from(R_tilt, [3 * spacing_x, spacing_y, 0.4])
+fig.plot_camera(
+    M=M, cam2world=cam2world, virtual_image_distance=0.55, sensor_size=(w, h)
+)
+fig.plot_transform(A2B=cam2world, s=0.35)
+
+if "__file__" in globals():
+    fig.show()
+    input("Press Enter to exit...")

--- a/examples/viser/vis_viser_shapes.py
+++ b/examples/viser/vis_viser_shapes.py
@@ -4,9 +4,10 @@ Geometric Primitives
 ====================
 
 All geometric primitive shapes supported by the viser backend are arranged
-in two rows. The first row shows sphere, box, cylinder, and capsule. The
-second row shows cone, ellipsoid, plane, and a camera frustum. Each shape is
-accompanied by a small coordinate frame at its origin.
+in two rows in the x-z ground plane (viser uses y-up). The first row shows
+sphere, box, cylinder, and capsule. The second row shows cone, ellipsoid,
+plane, and a camera frustum. Each shape is accompanied by a small coordinate
+frame at its origin.
 
 This example can be used as a reference for the available shapes and their
 constructor arguments.
@@ -19,8 +20,15 @@ from pytransform3d.transformations import transform_from
 
 fig = pv.figure()
 
+# Viser is y-up: shapes are laid out in the x-z ground plane.
+# Row 0 is at z=0, row 1 is at z=spacing_z.
 spacing_x = 1.8
-spacing_y = 2.0
+spacing_z = 2.0
+
+# Center of the 4 x 2 layout; distance chosen to frame all shapes.
+fig.view_init(
+    azim=30, elev=30, center=(1.5 * spacing_x, 0.0, 0.5 * spacing_z), distance=9.0
+)
 
 # %%
 # Row 0: sphere, box, cylinder, capsule
@@ -58,13 +66,13 @@ fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
 # Row 1: cone, ellipsoid, plane, camera frustum
 # -----------------------------------------------
 
-p = np.array([0 * spacing_x, spacing_y, 0.0])
+p = np.array([0 * spacing_x, 0.0, spacing_z])
 fig.plot_cone(
     height=0.7, radius=0.3, A2B=transform_from(np.eye(3), p), c=(0.85, 0.4, 0.1)
 )
 fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
 
-p = np.array([1 * spacing_x, spacing_y, 0.0])
+p = np.array([1 * spacing_x, 0.0, spacing_z])
 fig.plot_ellipsoid(
     radii=[0.5, 0.28, 0.18],
     A2B=transform_from(np.eye(3), p),
@@ -72,8 +80,8 @@ fig.plot_ellipsoid(
 )
 fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
 
-p = np.array([2 * spacing_x, spacing_y, 0.0])
-fig.plot_plane(normal=[0, 0, 1], point_in_plane=p, s=0.6, c=(0.1, 0.75, 0.75))
+p = np.array([2 * spacing_x, 0.0, spacing_z])
+fig.plot_plane(normal=[0, 1, 0], point_in_plane=p, s=0.6, c=(0.1, 0.75, 0.75))
 fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
 
 # %%
@@ -82,7 +90,7 @@ fig.plot_transform(A2B=transform_from(np.eye(3), p), s=0.35)
 fl = 500.0
 w, h = 640, 480
 M = np.array([[fl, 0, w / 2.0], [0, fl, h / 2.0], [0, 0, 1]], dtype=float)
-# Tilt the camera 30 degrees downward so the frustum is easy to see.
+# Tilt the camera 30 degrees around x so the frustum is easy to see.
 tilt = np.pi / 6.0
 R_tilt = np.array(
     [
@@ -91,7 +99,7 @@ R_tilt = np.array(
         [0, np.sin(tilt), np.cos(tilt)],
     ]
 )
-cam2world = transform_from(R_tilt, [3 * spacing_x, spacing_y, 0.4])
+cam2world = transform_from(R_tilt, [3 * spacing_x, 0.4, spacing_z])
 fig.plot_camera(
     M=M, cam2world=cam2world, virtual_image_distance=0.55, sensor_size=(w, h)
 )
@@ -100,3 +108,5 @@ fig.plot_transform(A2B=cam2world, s=0.35)
 if "__file__" in globals():
     fig.show()
     input("Press Enter to exit...")
+else:
+    fig.save_image("__viser_rendered_image.jpg")

--- a/examples/viser/vis_viser_uncertain_transforms.py
+++ b/examples/viser/vis_viser_uncertain_transforms.py
@@ -1,0 +1,219 @@
+"""
+================================
+Concatenate Uncertain Transforms
+================================
+
+In this example, we assume that a robot is moving with constant velocity
+along the x-axis, however, there is noise in the orientation of the robot
+that accumulates and leads to different paths when sampling. Uncertainty
+accumulation leads to the so-called banana distribution, which does not seem
+Gaussian in Cartesian space, but it is Gaussian in exponential coordinates
+of SE(3).
+
+This example is adapted and modified to 3D from Barfoot and Furgale [1]_.
+The banana distribution was analyzed in detail by Long et al. [2]_.
+"""
+
+import numpy as np
+import trimesh
+
+import pytransform3d.rotations as pr
+import pytransform3d.trajectories as ptr
+import pytransform3d.transformations as pt
+import pytransform3d.uncertainty as pu
+import pytransform3d.viser as pv
+
+# %%
+# Configuration
+# -------------
+# We assume :math:`\Delta t = 1 s` and constant velocity. The covariance
+# models rotational noise that accumulates over the trajectory.
+rng = np.random.default_rng(0)
+cov_pose_chol = np.diag([0, 0.02, 0.03, 0, 0, 0])
+cov_pose = np.dot(cov_pose_chol, cov_pose_chol.T)
+velocity_vector = np.array([0, 0, 0, 1.0, 0, 0])
+T_vel = pt.transform_from_exponential_coordinates(velocity_vector)
+n_steps = 100
+n_mc_samples = 1000
+
+# %%
+# Estimated mean trajectory and accumulated covariance
+# -----------------------------------------------------
+T_est = np.eye(4)
+path = np.zeros((n_steps + 1, 6))
+path[0] = pt.exponential_coordinates_from_transform(T_est)
+cov_est = np.zeros((6, 6))
+for t in range(n_steps):
+    T_est, cov_est = pu.concat_globally_uncertain_transforms(
+        T_est, cov_est, T_vel, cov_pose
+    )
+    path[t + 1] = pt.exponential_coordinates_from_transform(T_est)
+
+# %%
+# Monte-Carlo sampling
+# --------------------
+T = np.eye(4)
+mc_path = np.zeros((n_steps + 1, n_mc_samples, 4, 4))
+mc_path[0, :] = T
+for t in range(n_steps):
+    noise_samples = ptr.transforms_from_exponential_coordinates(
+        cov_pose_chol.dot(rng.standard_normal(size=(6, n_mc_samples))).T
+    )
+    step_samples = ptr.concat_many_to_one(noise_samples, T_vel)
+    mc_path[t + 1] = np.einsum("nij,njk->nik", step_samples, mc_path[t])
+mc_path_vec = np.einsum(
+    "tinm,tin->tim", mc_path[:, :, :3, :3], mc_path[:, :, :3, 3]
+)
+
+# %%
+# Surface helper
+# --------------
+
+
+def grid_to_mesh(x, y, z):
+    """Triangulate a surface defined by grid arrays.
+
+    Parameters
+    ----------
+    x : array, shape (m, n)
+        x-coordinates of the surface grid.
+
+    y : array, shape (m, n)
+        y-coordinates of the surface grid.
+
+    z : array, shape (m, n)
+        z-coordinates of the surface grid.
+
+    Returns
+    -------
+    vertices : array, shape (m*n, 3)
+        Vertex positions.
+
+    faces : array, shape ((m-1)*(n-1)*2, 3)
+        Triangle face indices.
+    """
+    m, n = x.shape
+    vertices = np.column_stack([x.ravel(), y.ravel(), z.ravel()]).astype(
+        np.float32
+    )
+    triangles = []
+    for i in range(m - 1):
+        for j in range(n - 1):
+            v00 = i * n + j
+            v10 = (i + 1) * n + j
+            v11 = (i + 1) * n + j + 1
+            v01 = i * n + j + 1
+            triangles.extend([[v00, v10, v11], [v00, v11, v01]])
+    return vertices, np.array(triangles, dtype=np.int32)
+
+
+# %%
+# Scene setup
+# -----------
+fig = pv.figure()
+# The scene extends ~100 units along the x-axis and ~30 units along y.
+# azim=0, elev=0 places the camera at +z from center, looking along -z so
+# that x goes right and y goes up — the banana in the x-y plane is fully
+# visible.  distance=120 is large enough to frame the whole trajectory.
+fig.view_init(azim=0, elev=0, center=(50.0, 0.0, 5.0), distance=120.0)
+
+# %%
+# MC-sampled trajectories (every 10th path to keep rendering fast)
+# -----------------------------------------------------------------
+# A light blue colour approximates the low-opacity effect used in the
+# matplotlib version.
+for i in range(0, n_mc_samples, 10):
+    fig.plot(mc_path_vec[:, i, :], c=(0.6, 0.75, 1.0))
+
+# %%
+# Scatter of final MC positions
+# ------------------------------
+fig.scatter(mc_path_vec[-1], s=0.4, c=(0.0, 0.0, 0.8))
+
+# %%
+# Mean trajectory with coordinate frames
+# ----------------------------------------
+fig.plot_trajectory(
+    ptr.pqs_from_transforms(ptr.transforms_from_exponential_coordinates(path)),
+    n_frames=10,
+    s=5.0,
+)
+
+# %%
+# Projected hyperellipsoid of the final pose distribution
+# --------------------------------------------------------
+# This is the "banana" shape: the 3D projection of the equiprobable
+# hyper-ellipsoid of the Gaussian in SE(3) tangent space.
+x, y, z = pu.to_projected_ellipsoid(T_est, cov_est, factor=3.0, n_steps=50)
+banana_verts, banana_faces = grid_to_mesh(x, y, z)
+yellow = (230, 210, 20)
+fig.scene.add_mesh_simple(
+    name="/banana/solid",
+    vertices=banana_verts,
+    faces=banana_faces,
+    color=yellow,
+    opacity=0.3,
+    side="double",
+)
+fig.scene.add_mesh_simple(
+    name="/banana/wireframe",
+    vertices=banana_verts,
+    faces=banana_faces,
+    color=yellow,
+    wireframe=True,
+    side="double",
+)
+
+# %%
+# Position-only ellipsoid from MC samples
+# ----------------------------------------
+# This is the ellipsoid fitted to the spread of the final positions of the
+# sampled trajectories in Cartesian space.
+mean_mc = np.mean(mc_path_vec[-1], axis=0)
+cov_mc = np.cov(mc_path_vec[-1], rowvar=False)
+ellipsoid2origin, radii = pu.to_ellipsoid(mean_mc, cov_mc)
+ell_mesh = trimesh.creation.icosphere(subdivisions=3)
+ell_mesh.vertices = ell_mesh.vertices * (3.0 * radii[np.newaxis])
+ell_verts = ell_mesh.vertices.astype(np.float32)
+ell_faces = np.array(ell_mesh.faces, dtype=np.int32)
+ell_wxyz = pr.quaternion_from_matrix(
+    ellipsoid2origin[:3, :3], strict_check=False
+)
+ell_pos = ellipsoid2origin[:3, 3].astype(np.float32)
+magenta = (210, 30, 210)
+fig.scene.add_mesh_simple(
+    name="/pos_ellipsoid/solid",
+    vertices=ell_verts,
+    faces=ell_faces,
+    color=magenta,
+    opacity=0.1,
+    side="double",
+    wxyz=ell_wxyz,
+    position=ell_pos,
+)
+fig.scene.add_mesh_simple(
+    name="/pos_ellipsoid/wireframe",
+    vertices=ell_verts,
+    faces=ell_faces,
+    color=magenta,
+    wireframe=True,
+    side="double",
+    wxyz=ell_wxyz,
+    position=ell_pos,
+)
+
+if "__file__" in globals():
+    fig.show()
+    input("Press Enter to exit...")
+
+# %%
+# References
+# ----------
+# .. [1] Barfoot, T. D., Furgale, P. T. (2014). Associating Uncertainty With
+#    Three-Dimensional Poses for Use in Estimation Problems. IEEE Transactions
+#    on Robotics 30(3), pp. 679-693, doi: 10.1109/TRO.2014.2298059.
+#
+# .. [2] Long, A. W., Wolfe, K. C., Mashner, M. J., Chirikjian, G. S. (2013).
+#    The Banana Distribution is Gaussian: A Localization Study with Exponential
+#    Coordinates. In Robotics: Science and Systems VIII, pp. 265-272.
+#    http://www.roboticsproceedings.org/rss08/p34.pdf

--- a/examples/viser/vis_viser_uncertain_transforms.py
+++ b/examples/viser/vis_viser_uncertain_transforms.py
@@ -205,6 +205,8 @@ fig.scene.add_mesh_simple(
 if "__file__" in globals():
     fig.show()
     input("Press Enter to exit...")
+else:
+    fig.save_image("__viser_rendered_image.jpg")
 
 # %%
 # References

--- a/examples/viser/vis_viser_wrench_dynamics.py
+++ b/examples/viser/vis_viser_wrench_dynamics.py
@@ -1,0 +1,161 @@
+"""
+=================================
+Rigid Body Dynamics Under Wrench
+=================================
+
+A constant body-fixed wrench is applied to a cylinder. At each time step we
+integrate the resulting spatial acceleration to get the body twist and then
+update the pose using exponential coordinates. The trajectory of the
+cylinder's origin is drawn in real time as the simulation progresses.
+
+The rigid-body equations of motion in body coordinates are::
+
+    G * Sdot = W - ad(S)^T * G * S
+
+where G is the 6x6 spatial inertia matrix, S is the body twist (screw
+velocity), W is the wrench expressed in body coordinates, and ad(S)^T is the
+adjoint map used to account for Coriolis effects. Here we neglect Coriolis
+forces for simplicity and integrate directly with::
+
+    Sdot = G^-1 * W
+
+The pose update uses the matrix exponential::
+
+    body2world(t+dt) = exp(dt * S) * body2world(t)
+"""
+
+import numpy as np
+
+import pytransform3d.viser as pv
+from pytransform3d.transformations import transform_from_exponential_coordinates
+
+
+def spatial_inertia_of_cylinder(mass, length, radius):
+    """Compute the 6x6 spatial inertia matrix of a uniform cylinder.
+
+    The cylinder axis is aligned with the z-axis of its body frame.
+
+    Parameters
+    ----------
+    mass : float
+        Total mass [kg].
+
+    length : float
+        Length along z-axis [m].
+
+    radius : float
+        Radius [m].
+
+    Returns
+    -------
+    G : array, shape (6, 6)
+        Spatial inertia matrix (rotation part first, then translation).
+    """
+    I_xx = I_yy = 0.25 * mass * radius**2 + (1.0 / 12.0) * mass * length**2
+    I_zz = 0.5 * mass * radius**2
+    G = np.eye(6)
+    G[:3, :3] *= np.array([I_xx, I_yy, I_zz])
+    G[3:, 3:] *= mass
+    return G
+
+
+# %%
+# Cylinder parameters and initial state
+# ---------------------------------------
+
+mass = 1.0
+length = 0.5
+radius = 0.1
+G_inv = np.linalg.inv(spatial_inertia_of_cylinder(mass, length, radius))
+
+# Body-fixed wrench: small torques about x/y and a force along y.
+# This combination causes a tumbling corkscrew motion.
+wrench_in_body = np.array([0.08, 0.04, 0.005, 0.0, 0.8, 0.5])
+
+dt = 0.001
+n_frames = 5000
+# We collect a fixed-length rolling window of positions for the trail.
+trail_length = 300
+
+# %%
+# Scene setup
+# -----------
+
+fig = pv.figure()
+
+body2world = np.eye(4)
+twist = np.zeros(6)
+
+cylinder = fig.plot_cylinder(length=length, radius=radius, c=(0.9, 0.55, 0.1))
+body_frame = fig.plot_transform(A2B=body2world, s=0.25)
+world_frame = fig.plot_transform(A2B=np.eye(4), s=0.4)
+
+# Trail line: start with two coincident points at the origin.
+trail_positions = [np.zeros(3), np.zeros(3)]
+trail_line = pv.Line3D(P=np.array(trail_positions), c=(0.2, 0.6, 1.0))
+trail_line.add_artist(fig)
+
+
+# %%
+# Simulation and animation callback
+# -----------------------------------
+def animation_callback(step, cylinder, body_frame, trail_line, state):
+    """Advance the simulation by one frame and update the scene.
+
+    One animation frame covers multiple integration steps so the motion
+    appears smooth even at 30 fps.
+
+    Parameters
+    ----------
+    step : int
+        Current animation frame index (unused, state is in ``state``).
+    cylinder : Cylinder
+        Cylinder artist.
+    body_frame : Frame
+        Coordinate frame artist attached to the cylinder.
+    trail_line : Line3D
+        Trail showing the history of the cylinder origin.
+    state : list
+        Mutable container ``[body2world, twist, trail_positions]``.
+
+    Returns
+    -------
+    artists : tuple
+        Updated artists.
+    """
+    body2world, twist, trail_positions = state
+
+    # Integrate multiple steps per animation frame for smoother motion.
+    steps_per_frame = 10
+    for _ in range(steps_per_frame):
+        twist += dt * G_inv.dot(wrench_in_body)
+        new_pose = transform_from_exponential_coordinates(dt * twist).dot(
+            body2world
+        )
+        body2world[:] = new_pose
+
+    # Update geometry.
+    cylinder.set_data(body2world)
+    body_frame.set_data(body2world)
+
+    # Append current position to the rolling trail.
+    trail_positions.append(body2world[:3, 3].copy())
+    if len(trail_positions) > trail_length:
+        trail_positions.pop(0)
+    trail_line.set_data(np.array(trail_positions))
+
+    state[0] = body2world
+    state[2] = trail_positions
+    return cylinder, body_frame, trail_line
+
+
+state = [body2world, twist, trail_positions]
+
+if "__file__" in globals():
+    fig.show()
+    fig.animate(
+        animation_callback,
+        n_frames,
+        loop=True,
+        fargs=(cylinder, body_frame, trail_line, state),
+    )

--- a/examples/viser/vis_viser_wrench_dynamics.py
+++ b/examples/viser/vis_viser_wrench_dynamics.py
@@ -159,3 +159,5 @@ if "__file__" in globals():
         loop=True,
         fargs=(cylinder, body_frame, trail_line, state),
     )
+else:
+    fig.save_image("__viser_rendered_image.jpg")

--- a/pytransform3d/_mesh_loader.py
+++ b/pytransform3d/_mesh_loader.py
@@ -110,7 +110,7 @@ class _Trimesh(MeshBase):
             else:
                 raise e
         self.mesh = trimesh.load_mesh(self.filename)
-        if isinstance(self.mesh, trimesh.Scene):
+        if isinstance(self.mesh, trimesh.Scene):  # pragma: no cover
             open3d_mesh = self._scene_to_open3d_mesh(self.mesh)
             self.mesh = self._open3d_mesh_to_trimesh(open3d_mesh)
         return True

--- a/pytransform3d/test/test_viser.py
+++ b/pytransform3d/test/test_viser.py
@@ -1,0 +1,499 @@
+"""Tests for the viser visualization backend."""
+
+import numpy as np
+import pytest
+
+viser = pytest.importorskip("viser")
+
+from pytransform3d.viser import (  # noqa: E402
+    Figure,
+    Artist,
+    Line3D,
+    PointCollection3D,
+    Vector3D,
+    Frame,
+    Trajectory,
+    Sphere,
+    Box,
+    Cylinder,
+    Ellipsoid,
+    Capsule,
+    Cone,
+    Plane,
+    Camera,
+    Graph,
+)
+from pytransform3d.transform_manager import TransformManager  # noqa: E402
+
+# Sequential port counter to avoid port conflicts between tests
+_PORT = [9200]
+
+
+def _next_port():
+    _PORT[0] += 1
+    return _PORT[0]
+
+
+@pytest.fixture
+def fig():
+    f = Figure(port=_next_port())
+    yield f
+    f._server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Artist unit tests (no figure required)
+# ---------------------------------------------------------------------------
+
+
+def test_artist_base():
+    a = Artist()
+    assert a.geometries == []
+    a.add_artist(None)  # should not raise
+    a.remove()  # should not raise
+
+
+def test_line3d_init():
+    P = np.array([[0, 0, 0], [1, 0, 0], [2, 1, 0]], dtype=float)
+    line = Line3D(P)
+    assert line._handle is None
+
+
+def test_line3d_single_color():
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    line = Line3D(P, c=(1, 0, 0))
+    assert line._handle is None
+
+
+def test_line3d_per_segment_colors():
+    P = np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=float)
+    c = np.array([[1, 0, 0], [0, 1, 0]], dtype=float)
+    line = Line3D(P, c=c)
+    assert line._handle is None
+
+
+def test_point_collection_init():
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    pc = PointCollection3D(P, s=0.1, c=(0, 1, 0))
+    assert pc._handle is None
+
+
+def test_vector3d_init():
+    v = Vector3D(start=[0, 0, 0], direction=[1, 0, 0], c=(0, 0, 1))
+    assert v._handle is None
+
+
+def test_vector3d_zero_direction():
+    v = Vector3D(start=[0, 0, 0], direction=[0, 0, 0])
+    assert v._handle is None
+
+
+def test_frame_init():
+    f = Frame(np.eye(4), s=1.0)
+    assert f._handle is None
+
+
+def test_frame_with_label():
+    f = Frame(np.eye(4), label="test", s=0.5)
+    assert f.label == "test"
+
+
+def test_trajectory_init():
+    H = np.tile(np.eye(4), (10, 1, 1))
+    traj = Trajectory(H, n_frames=5, s=0.2)
+    assert len(traj.key_frames) == 5
+
+
+def test_sphere_init():
+    s = Sphere(radius=0.5, c=(1, 0, 0))
+    assert s._handle is None
+
+
+def test_sphere_no_color():
+    s = Sphere(radius=1.0)
+    assert s.c is None
+
+
+def test_box_init():
+    b = Box(size=[1, 2, 3], c=(0, 0, 1))
+    assert b._handle is None
+
+
+def test_cylinder_init():
+    c = Cylinder(length=2.0, radius=0.5, resolution=16)
+    assert c._handle is None
+
+
+def test_cylinder_split_ignored():
+    # split parameter accepted for API compatibility but not used
+    c = Cylinder(length=1.0, radius=0.5, split=8)
+    assert c._handle is None
+
+
+def test_ellipsoid_init():
+    e = Ellipsoid(radii=[1, 2, 3])
+    assert e._handle is None
+
+
+def test_capsule_init():
+    cap = Capsule(height=1.0, radius=0.3)
+    assert cap._handle is None
+
+
+def test_cone_init():
+    co = Cone(height=1.0, radius=0.5)
+    assert co._handle is None
+
+
+def test_plane_init_with_d():
+    pl = Plane(normal=[0, 0, 1], d=0.5)
+    assert pl.d == 0.5
+
+
+def test_plane_init_with_point():
+    pl = Plane(normal=[0, 0, 1], point_in_plane=[0, 0, 1])
+    assert pl.point_in_plane is not None
+
+
+def test_plane_missing_both_raises():
+    pl = Plane(normal=[0, 0, 1])
+    with pytest.raises(ValueError, match="Either 'd' or 'point_in_plane'"):
+        pl._resolve_point(pl.normal, pl.d, pl.point_in_plane)
+
+
+def test_camera_init():
+    M = np.array([[800, 0, 960], [0, 800, 540], [0, 0, 1]], dtype=float)
+    cam = Camera(M)
+    assert cam._handle is None
+
+
+def test_camera_init_with_cam2world():
+    M = np.array([[800, 0, 960], [0, 800, 540], [0, 0, 1]], dtype=float)
+    cam2world = np.eye(4)
+    cam = Camera(M, cam2world=cam2world)
+    assert cam._handle is None
+
+
+# ---------------------------------------------------------------------------
+# Figure integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_figure_creation(fig):
+    assert fig._server is not None
+    assert fig._object_count == 0
+
+
+def test_figure_show_prints_url(fig, capsys):
+    fig.show()
+    captured = capsys.readouterr()
+    assert "localhost" in captured.out
+
+
+def test_figure_save_image_raises(fig):
+    with pytest.raises(NotImplementedError):
+        fig.save_image("test.png")
+
+
+def test_figure_set_line_width_warns(fig):
+    with pytest.warns(UserWarning):
+        fig.set_line_width(2.0)
+
+
+def test_plot_line(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0], [2, 1, 0]], dtype=float)
+    line = fig.plot(P)
+    assert isinstance(line, Line3D)
+    assert line._handle is not None
+
+
+def test_plot_line_single_point_no_handle(fig):
+    P = np.array([[0, 0, 0]], dtype=float)
+    line = fig.plot(P)
+    assert isinstance(line, Line3D)
+    assert line._handle is None  # not enough points
+
+
+def test_plot_line_set_data(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    line = fig.plot(P)
+    P2 = np.array([[0, 0, 0], [0, 1, 0]], dtype=float)
+    line.set_data(P2)  # should not raise
+
+
+def test_scatter(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=float)
+    pc = fig.scatter(P, s=0.05, c=(1, 0, 0))
+    assert isinstance(pc, PointCollection3D)
+    assert pc._handle is not None
+
+
+def test_scatter_no_color(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    pc = fig.scatter(P)
+    assert isinstance(pc, PointCollection3D)
+
+
+def test_scatter_per_point_color(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    c = np.array([[1, 0, 0], [0, 1, 0]], dtype=float)
+    pc = fig.scatter(P, c=c)
+    assert isinstance(pc, PointCollection3D)
+
+
+def test_scatter_set_data(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    pc = fig.scatter(P)
+    pc.set_data(np.array([[0, 0, 0], [0, 1, 0]], dtype=float))
+
+
+def test_plot_vector(fig):
+    v = fig.plot_vector([0, 0, 0], [1, 0, 0], c=(0, 1, 0))
+    assert isinstance(v, Vector3D)
+    assert v._handle is not None
+
+
+def test_plot_vector_zero_length(fig):
+    v = fig.plot_vector([0, 0, 0], [0, 0, 0])
+    assert isinstance(v, Vector3D)
+    assert v._handle is None
+
+
+def test_plot_vector_set_data(fig):
+    v = fig.plot_vector([0, 0, 0], [1, 0, 0])
+    v.set_data([0, 0, 0], [0, 1, 0])
+    assert v._handle is not None
+
+
+def test_plot_basis(fig):
+    f = fig.plot_basis()
+    assert isinstance(f, Frame)
+    assert f._handle is not None
+
+
+def test_plot_basis_with_rotation(fig):
+    R = np.eye(3)
+    f = fig.plot_basis(R=R, p=[1, 0, 0], s=0.5)
+    assert isinstance(f, Frame)
+
+
+def test_plot_transform_identity(fig):
+    f = fig.plot_transform(np.eye(4))
+    assert isinstance(f, Frame)
+    assert f._handle is not None
+
+
+def test_plot_transform_none(fig):
+    f = fig.plot_transform()
+    assert isinstance(f, Frame)
+
+
+def test_plot_transform_set_data(fig):
+    f = fig.plot_transform(np.eye(4))
+    f.set_data(np.eye(4))
+
+
+def test_plot_transform_with_name(fig):
+    f = fig.plot_transform(np.eye(4), name="world")
+    assert isinstance(f, Frame)
+
+
+def test_plot_trajectory(fig):
+    pqs = np.zeros((10, 7))
+    pqs[:, 0] = np.linspace(0, 1, 10)
+    pqs[:, 3] = 1.0
+    traj = fig.plot_trajectory(pqs, n_frames=5, s=0.2)
+    assert isinstance(traj, Trajectory)
+    assert traj.line._handle is not None
+    assert len(traj.key_frames) == 5
+
+
+def test_plot_trajectory_set_data(fig):
+    pqs = np.zeros((10, 7))
+    pqs[:, 0] = np.linspace(0, 1, 10)
+    pqs[:, 3] = 1.0
+    traj = fig.plot_trajectory(pqs, n_frames=3)
+    pqs2 = np.zeros((10, 7))
+    pqs2[:, 1] = np.linspace(0, 1, 10)
+    pqs2[:, 3] = 1.0
+    from pytransform3d.trajectories import transforms_from_pqs
+
+    traj.set_data(transforms_from_pqs(pqs2))
+
+
+def test_plot_sphere(fig):
+    s = fig.plot_sphere(radius=0.5, c=(1, 0, 0))
+    assert isinstance(s, Sphere)
+    assert s._handle is not None
+
+
+def test_plot_sphere_set_data(fig):
+    s = fig.plot_sphere(radius=0.5)
+    s.set_data(np.eye(4))
+
+
+def test_plot_box(fig):
+    b = fig.plot_box(size=[1, 2, 3], c=(0, 0, 1))
+    assert isinstance(b, Box)
+    assert b._handle is not None
+
+
+def test_plot_box_set_data(fig):
+    b = fig.plot_box()
+    b.set_data(np.eye(4))
+
+
+def test_plot_cylinder(fig):
+    c = fig.plot_cylinder(length=2.0, radius=0.5)
+    assert isinstance(c, Cylinder)
+    assert c._handle is not None
+
+
+def test_plot_cylinder_set_data(fig):
+    c = fig.plot_cylinder()
+    c.set_data(np.eye(4))
+
+
+def test_plot_ellipsoid(fig):
+    e = fig.plot_ellipsoid(radii=[1, 2, 3], c=(1, 0, 1))
+    assert isinstance(e, Ellipsoid)
+    assert e._handle is not None
+
+
+def test_plot_ellipsoid_set_data(fig):
+    e = fig.plot_ellipsoid(radii=[1, 1, 1])
+    e.set_data(np.eye(4))
+
+
+def test_plot_capsule(fig):
+    cap = fig.plot_capsule(height=1.0, radius=0.3)
+    assert isinstance(cap, Capsule)
+    assert cap._handle is not None
+
+
+def test_plot_capsule_set_data(fig):
+    cap = fig.plot_capsule()
+    cap.set_data(np.eye(4))
+
+
+def test_plot_cone(fig):
+    co = fig.plot_cone(height=1.0, radius=0.5, c=(1, 1, 0))
+    assert isinstance(co, Cone)
+    assert co._handle is not None
+
+
+def test_plot_cone_set_data(fig):
+    co = fig.plot_cone()
+    co.set_data(np.eye(4))
+
+
+def test_plot_plane_with_d(fig):
+    pl = fig.plot_plane(normal=[0, 0, 1], d=0.0)
+    assert isinstance(pl, Plane)
+    assert pl._handle is not None
+
+
+def test_plot_plane_with_point_in_plane(fig):
+    pl = fig.plot_plane(normal=[0, 0, 1], point_in_plane=[0, 0, 0])
+    assert isinstance(pl, Plane)
+
+
+def test_plot_plane_set_data(fig):
+    pl = fig.plot_plane(normal=[0, 0, 1], d=0.0)
+    pl.set_data(normal=[1, 0, 0], d=0.0)
+
+
+def test_plot_plane_set_data_raises_without_definition(fig):
+    pl = fig.plot_plane(normal=[0, 0, 1], d=0.0)
+    with pytest.raises(ValueError):
+        pl.set_data(normal=[0, 0, 1])
+
+
+def test_plot_camera(fig):
+    M = np.array([[800, 0, 960], [0, 800, 540], [0, 0, 1]], dtype=float)
+    cam = fig.plot_camera(M=M)
+    assert isinstance(cam, Camera)
+    assert cam._handle is not None
+
+
+def test_plot_camera_with_cam2world(fig):
+    M = np.array([[800, 0, 960], [0, 800, 540], [0, 0, 1]], dtype=float)
+    cam = fig.plot_camera(M=M, cam2world=np.eye(4), virtual_image_distance=0.5)
+    assert isinstance(cam, Camera)
+
+
+def test_plot_camera_set_data(fig):
+    M = np.array([[800, 0, 960], [0, 800, 540], [0, 0, 1]], dtype=float)
+    cam = fig.plot_camera(M=M)
+    cam.set_data(cam2world=np.eye(4))
+
+
+def test_plot_graph_empty(fig):
+    tm = TransformManager()
+    tm.add_transform("A", "world", np.eye(4))
+    g = fig.plot_graph(tm, "world")
+    assert isinstance(g, Graph)
+
+
+def test_plot_graph_with_frames(fig):
+    tm = TransformManager()
+    tm.add_transform("A", "world", np.eye(4))
+    tm.add_transform("B", "world", np.eye(4))
+    g = fig.plot_graph(tm, "world", show_frames=True, s=0.5)
+    assert isinstance(g, Graph)
+    assert len(g.frames) == 3  # world, A, B
+
+
+def test_plot_graph_with_connections(fig):
+    tm = TransformManager()
+    tm.add_transform("A", "world", np.eye(4))
+    g = fig.plot_graph(tm, "world", show_connections=True)
+    assert isinstance(g, Graph)
+    assert len(g.connections) == 1
+
+
+def test_plot_graph_set_data(fig):
+    tm = TransformManager()
+    tm.add_transform("A", "world", np.eye(4))
+    g = fig.plot_graph(tm, "world", show_frames=True)
+    g.set_data()
+
+
+def test_plot_graph_unknown_frame_raises(fig):
+    tm = TransformManager()
+    tm.add_transform("A", "world", np.eye(4))
+    with pytest.raises(KeyError):
+        fig.plot_graph(tm, "nonexistent")
+
+
+def test_remove_artist_line(fig):
+    P = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    line = fig.plot(P)
+    fig.remove_artist(line)
+    assert line._handle is None
+
+
+def test_remove_artist_sphere(fig):
+    s = fig.plot_sphere()
+    fig.remove_artist(s)
+    assert s._handle is None
+
+
+def test_remove_artist_graph(fig):
+    tm = TransformManager()
+    tm.add_transform("A", "world", np.eye(4))
+    g = fig.plot_graph(tm, "world", show_frames=True, show_connections=True)
+    fig.remove_artist(g)
+
+
+def test_remove_artist_trajectory(fig):
+    pqs = np.zeros((5, 7))
+    pqs[:, 3] = 1.0
+    traj = fig.plot_trajectory(pqs, n_frames=2)
+    fig.remove_artist(traj)
+
+
+def test_next_name_increments(fig):
+    n1 = fig._next_name("test")
+    n2 = fig._next_name("test")
+    assert n1 != n2

--- a/pytransform3d/test/test_viser.py
+++ b/pytransform3d/test/test_viser.py
@@ -1,5 +1,7 @@
 """Tests for the viser visualization backend."""
 
+import os
+
 import numpy as np
 import pytest
 
@@ -190,9 +192,11 @@ def test_figure_show_prints_url(fig, capsys):
     assert "localhost" in captured.out
 
 
-def test_figure_save_image_raises(fig):
-    with pytest.raises(NotImplementedError):
-        fig.save_image("test.png")
+def test_figure_save_image(fig):
+    pytest.importorskip("playwright")
+    pytest.importorskip("imageio")
+    fig.save_image("/tmp/test_viser_save.jpg")
+    assert os.path.exists("/tmp/test_viser_save.jpg")
 
 
 def test_figure_set_line_width_warns(fig):

--- a/pytransform3d/viser/__init__.py
+++ b/pytransform3d/viser/__init__.py
@@ -1,0 +1,53 @@
+"""Optional 3D renderer based on viser."""
+
+import warnings
+
+try:
+    import viser as _viser  # noqa: F401
+
+    from ._artists import (
+        Artist,
+        Line3D,
+        PointCollection3D,
+        Vector3D,
+        Frame,
+        Trajectory,
+        Camera,
+        Box,
+        Sphere,
+        Cylinder,
+        Mesh,
+        Ellipsoid,
+        Capsule,
+        Cone,
+        Plane,
+        Graph,
+    )
+    from ._figure import figure, Figure
+
+    __all__ = [
+        "figure",
+        "Figure",
+        "Artist",
+        "Line3D",
+        "PointCollection3D",
+        "Vector3D",
+        "Frame",
+        "Trajectory",
+        "Camera",
+        "Box",
+        "Sphere",
+        "Cylinder",
+        "Mesh",
+        "Ellipsoid",
+        "Capsule",
+        "Cone",
+        "Plane",
+        "Graph",
+    ]
+except ImportError:
+    warnings.warn(
+        "3D visualizer is not available. Install viser.",
+        ImportWarning,
+        stacklevel=2,
+    )

--- a/pytransform3d/viser/_artists.py
+++ b/pytransform3d/viser/_artists.py
@@ -1243,13 +1243,74 @@ class Camera(Artist):
         self.strict_check = strict_check
         self._handle = None
 
-    def _fov_and_aspect(self):
-        fy = self.M[1, 1]
-        h = self.sensor_size[1]
-        w = self.sensor_size[0]
-        fov = 2.0 * np.arctan(h / (2.0 * fy))
-        aspect = float(w) / float(h)
-        return fov, aspect
+    def _compute_segments(self):
+        """Compute the 11 line segments that form the camera wireframe.
+
+        The wireframe consists of four frustum rays from the camera centre to
+        the corners of the virtual image plane, the rectangle connecting those
+        corners, and a small triangle above the top edge that indicates the
+        camera's up direction.
+
+        Returns
+        -------
+        segments : array, shape (11, 2, 3)
+            Line segments in world coordinates.
+        """
+        cam2world = self.cam2world
+        focal_length = float(np.mean([self.M[0, 0], self.M[1, 1]]))
+        w, h = float(self.sensor_size[0]), float(self.sensor_size[1])
+        cx, cy = float(self.M[0, 2]), float(self.M[1, 2])
+
+        corners_in_cam = np.array(
+            [
+                [0.0 - cx, 0.0 - cy, focal_length],
+                [0.0 - cx, h - cy, focal_length],
+                [w - cx, h - cy, focal_length],
+                [w - cx, 0.0 - cy, focal_length],
+            ]
+        )
+        corners_in_world = pt.transform(
+            cam2world, pt.vectors_to_points(corners_in_cam)
+        )[:, :3]
+
+        camera_center = cam2world[:3, 3]
+        virtual_corners = (
+            self.virtual_image_distance
+            / focal_length
+            * (corners_in_world - camera_center[np.newaxis])
+            + camera_center[np.newaxis]
+        )
+
+        up = virtual_corners[0] - virtual_corners[1]
+        pts = np.array(
+            [
+                camera_center,
+                virtual_corners[0],
+                virtual_corners[1],
+                virtual_corners[2],
+                virtual_corners[3],
+                virtual_corners[0] + 0.1 * up,
+                0.5 * (virtual_corners[0] + virtual_corners[3]) + 0.5 * up,
+                virtual_corners[3] + 0.1 * up,
+            ]
+        )
+
+        pairs = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 4),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 1),
+            (5, 6),
+            (6, 7),
+            (7, 5),
+        ]
+        return np.array(
+            [[pts[i], pts[j]] for i, j in pairs], dtype=np.float32
+        )
 
     def add_artist(self, figure):
         """Add artist to figure.
@@ -1259,14 +1320,13 @@ class Camera(Artist):
         figure : Figure
             Figure to which the artist will be added.
         """
-        fov, aspect = self._fov_and_aspect()
-        self._handle = figure.scene.add_camera_frustum(
+        segments = self._compute_segments()
+        n = len(segments)
+        colors = np.zeros((n, 1, 3), dtype=np.uint8)
+        self._handle = figure.scene.add_line_segments(
             name=figure._next_name("camera"),
-            fov=fov,
-            aspect=aspect,
-            scale=self.virtual_image_distance,
-            wxyz=_wxyz_from_matrix(self.cam2world),
-            position=self.cam2world[:3, 3],
+            points=segments,
+            colors=colors,
         )
 
     def set_data(
@@ -1313,12 +1373,7 @@ class Camera(Artist):
             self.sensor_size = sensor_size
         if self._handle is None:
             return
-        fov, aspect = self._fov_and_aspect()
-        self._handle.fov = fov
-        self._handle.aspect = aspect
-        self._handle.scale = self.virtual_image_distance
-        self._handle.wxyz = _wxyz_from_matrix(self.cam2world)
-        self._handle.position = self.cam2world[:3, 3]
+        self._handle.points = self._compute_segments()
 
     def remove(self):
         """Remove artist from figure."""

--- a/pytransform3d/viser/_artists.py
+++ b/pytransform3d/viser/_artists.py
@@ -436,6 +436,7 @@ class Frame(Artist):
         self._handle.position = self.A2B[:3, 3]
         if self._label_handle is not None:
             self._label_handle.position = self.A2B[:3, 3]
+            self._label_handle.text = self.label
 
     def remove(self):
         """Remove artist from figure."""
@@ -481,8 +482,6 @@ class Trajectory(Artist):
         for key_frame_idx in self.key_frames_indices:
             self.key_frames.append(Frame(self.H[key_frame_idx], s=self.s))
 
-        self.set_data(H)
-
     def add_artist(self, figure):
         """Add artist to figure.
 
@@ -505,6 +504,10 @@ class Trajectory(Artist):
         """
         self.H = np.asarray(H, dtype=float)
         self.line.set_data(self.H[:, :3, 3])
+        if len(self.H) != self.key_frames_indices[-1] + 1:
+            self.key_frames_indices = np.linspace(
+                0, len(self.H) - 1, self.n_frames, dtype=np.int64
+            )
         for i, key_frame_idx in enumerate(self.key_frames_indices):
             self.key_frames[i].set_data(self.H[key_frame_idx])
 
@@ -1099,7 +1102,11 @@ class Plane(Artist):
             raise ValueError(
                 "Either 'd' or 'point_in_plane' has to be defined!"
             )
-        return d * np.asarray(normal, dtype=float)
+        normal = np.asarray(normal, dtype=float)
+        normal_norm = np.linalg.norm(normal)
+        if normal_norm > 0.0:
+            normal = normal / normal_norm
+        return d * normal
 
     def _make_mesh(self):
         point = self._resolve_point(self.normal, self.d, self.point_in_plane)
@@ -1113,9 +1120,7 @@ class Plane(Artist):
             ],
             dtype=np.float32,
         )
-        faces = np.array(
-            [[0, 1, 2], [1, 3, 2], [2, 1, 0], [2, 3, 1]], dtype=np.int32
-        )
+        faces = np.array([[0, 1, 2], [1, 3, 2]], dtype=np.int32)
         return vertices, faces
 
     def add_artist(self, figure):
@@ -1519,12 +1524,18 @@ class Graph(Artist):
                     pass
 
         for frame_name, obj in self.visuals.items():
-            A2B = self.tm.get_transform(frame_name, self.frame)
-            obj.set_data(A2B)
+            try:
+                A2B = self.tm.get_transform(frame_name, self.frame)
+                obj.set_data(A2B)
+            except KeyError:
+                pass
 
         for frame_name, obj in self.collision_objects.items():
-            A2B = self.tm.get_transform(frame_name, self.frame)
-            obj.set_data(A2B)
+            try:
+                A2B = self.tm.get_transform(frame_name, self.frame)
+                obj.set_data(A2B)
+            except KeyError:
+                pass
 
     def remove(self):
         """Remove artist from figure."""

--- a/pytransform3d/viser/_artists.py
+++ b/pytransform3d/viser/_artists.py
@@ -1,0 +1,1525 @@
+"""Visualizer artists for the viser backend."""
+
+import warnings
+from itertools import chain
+
+import numpy as np
+import trimesh
+import trimesh.creation
+import trimesh.util
+import trimesh.visual
+
+from .. import rotations as pr
+from .. import transformations as pt
+from .. import urdf
+
+
+def _to_viser_color(c):
+    """Convert color from [0, 1] floats to (r, g, b) tuple with 0-255 ints.
+
+    Parameters
+    ----------
+    c : array-like, shape (3,) or None
+        RGB color with values in [0, 1], or None.
+
+    Returns
+    -------
+    color : tuple of int or None
+        RGB color with values in [0, 255], or None.
+    """
+    if c is None:
+        return None
+    arr = np.asarray(c, dtype=float)
+    return tuple(int(np.clip(v * 255.0, 0, 255)) for v in arr[:3])
+
+
+def _wxyz_from_matrix(A2B):
+    """Extract quaternion (wxyz) from a 4x4 homogeneous transform.
+
+    Parameters
+    ----------
+    A2B : array-like, shape (4, 4)
+        Homogeneous transformation matrix.
+
+    Returns
+    -------
+    wxyz : array, shape (4,)
+        Quaternion in wxyz convention.
+    """
+    return pr.quaternion_from_matrix(A2B[:3, :3], strict_check=False)
+
+
+def _make_arrow_mesh(length):
+    """Create a trimesh arrow pointing along the z-axis.
+
+    Parameters
+    ----------
+    length : float
+        Total length of the arrow.
+
+    Returns
+    -------
+    mesh : trimesh.Trimesh
+        Combined arrow mesh (shaft + tip).
+    """
+    shaft_length = length * 0.8
+    tip_length = length * 0.2
+    shaft_radius = 0.035 * length
+    tip_radius = 0.07 * length
+
+    shaft = trimesh.creation.cylinder(
+        radius=shaft_radius, height=shaft_length, sections=20
+    )
+    shaft.apply_translation([0.0, 0.0, shaft_length / 2.0])
+
+    tip = trimesh.creation.cone(
+        radius=tip_radius, height=tip_length, sections=20
+    )
+    tip.apply_translation([0.0, 0.0, shaft_length])
+
+    return trimesh.util.concatenate([shaft, tip])
+
+
+def _set_trimesh_color(mesh, c):
+    """Apply a uniform color to a trimesh mesh.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh to colorize.
+
+    c : array-like, shape (3,) or None
+        RGB color with values in [0, 1], or None.
+    """
+    if c is None:
+        return
+    viser_color = _to_viser_color(c)
+    n = len(mesh.vertices)
+    rgba = np.array([list(viser_color) + [255]], dtype=np.uint8)
+    mesh.visual = trimesh.visual.ColorVisuals(
+        mesh=mesh,
+        vertex_colors=np.tile(rgba, (n, 1)),
+    )
+
+
+class Artist:
+    """Abstract base class for objects that can be rendered."""
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+
+    def remove(self):
+        """Remove artist from figure."""
+
+    @property
+    def geometries(self):
+        """Expose geometries.
+
+        Returns
+        -------
+        geometries : list
+            Empty list (viser artists manage their own handles).
+        """
+        return []
+
+
+class Line3D(Artist):
+    """A line.
+
+    Parameters
+    ----------
+    P : array-like, shape (n_points, 3)
+        Points of which the line consists.
+
+    c : array-like, shape (n_points - 1, 3) or (3,), optional (default: black)
+        Color can be given as individual colors per line segment or as one
+        color for each segment. A color is represented by 3 values between
+        0 and 1 indicating red, green, and blue respectively.
+    """
+
+    def __init__(self, P, c=(0, 0, 0)):
+        self.P = np.asarray(P, dtype=float)
+        self.c = c
+        self._handle = None
+
+    def _make_segments(self):
+        return np.stack([self.P[:-1], self.P[1:]], axis=1).astype(np.float32)
+
+    def _make_colors(self, n_segments):
+        # viser add_line_segments broadcasts colors to points shape (N, 2, 3)
+        # so colors must be (N, 2, 3), (N, 1, 3), (1, 1, 3) or similar
+        c = np.asarray(self.c, dtype=float)
+        if c.ndim == 2 and len(c) == n_segments:
+            # Per-segment colors: shape (N, 3) -> (N, 1, 3) to broadcast
+            rgb = (np.clip(c, 0.0, 1.0) * 255).astype(np.uint8)
+            return rgb[:, np.newaxis, :]
+        color_1d = c if c.ndim == 1 else c[0]
+        rgb = _to_viser_color(color_1d)
+        return np.array([[list(rgb)]], dtype=np.uint8)  # shape (1, 1, 3)
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        if len(self.P) < 2:
+            return
+        segments = self._make_segments()
+        colors = self._make_colors(len(segments))
+        self._handle = figure.scene.add_line_segments(
+            name=figure._next_name("line"),
+            points=segments,
+            colors=colors,
+        )
+
+    def set_data(self, P, c=None):
+        """Update data.
+
+        Parameters
+        ----------
+        P : array-like, shape (n_points, 3)
+            Points of which the line consists.
+
+        c : array-like, shape (n_points - 1, 3) or (3,), optional
+            (default: None). Color can be given as individual colors per line
+            segment or as one color for each segment. A color is represented
+            by 3 values between 0 and 1 indicating red, green, and blue.
+        """
+        self.P = np.asarray(P, dtype=float)
+        if c is not None:
+            self.c = c
+        if self._handle is None or len(self.P) < 2:
+            return
+        segments = self._make_segments()
+        colors = self._make_colors(len(segments))
+        self._handle.points = segments
+        self._handle.colors = colors
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class PointCollection3D(Artist):
+    """Collection of points.
+
+    Parameters
+    ----------
+    P : array, shape (n_points, 3)
+        Points
+
+    s : float, optional (default: 0.05)
+        Scaling of the points that will be drawn.
+
+    c : array-like, shape (3,) or (n_points, 3), optional (default: None)
+        A color is represented by 3 values between 0 and 1 indicating
+        red, green, and blue respectively.
+    """
+
+    def __init__(self, P, s=0.05, c=None):
+        self.P = np.asarray(P, dtype=float)
+        self.s = s
+        self.c = c
+        self._handle = None
+
+    def _make_colors(self):
+        n = len(self.P)
+        if self.c is None:
+            return np.zeros((n, 3), dtype=np.uint8)
+        c = np.asarray(self.c, dtype=float)
+        if c.ndim == 1:
+            rgb = _to_viser_color(c)
+            return np.tile(np.array([list(rgb)], dtype=np.uint8), (n, 1))
+        return (np.clip(c, 0.0, 1.0) * 255).astype(np.uint8)
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        self._handle = figure.scene.add_point_cloud(
+            name=figure._next_name("points"),
+            points=self.P.astype(np.float32),
+            colors=self._make_colors(),
+            point_size=self.s,
+        )
+
+    def set_data(self, P):
+        """Update data.
+
+        Parameters
+        ----------
+        P : array, shape (n_points, 3)
+            Points
+        """
+        self.P = np.asarray(P, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.points = self.P.astype(np.float32)
+        self._handle.colors = self._make_colors()
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Vector3D(Artist):
+    """A vector.
+
+    Parameters
+    ----------
+    start : array-like, shape (3,), optional (default: [0, 0, 0])
+        Start of the vector
+
+    direction : array-like, shape (3,), optional (default: [1, 0, 0])
+        Direction of the vector
+
+    c : array-like, shape (3,), optional (default: black)
+        A color is represented by 3 values between 0 and 1 indicating
+        red, green, and blue respectively.
+    """
+
+    def __init__(
+        self, start=np.zeros(3), direction=np.array([1, 0, 0]), c=(0, 0, 0)
+    ):
+        self.start = np.asarray(start, dtype=float)
+        self.direction = np.asarray(direction, dtype=float)
+        self.c = c
+        self._handle = None
+        self._name = None
+        self._figure = None
+
+    def _pose_and_length(self):
+        length = np.linalg.norm(self.direction)
+        if length < 1e-10:
+            return length, np.eye(4)
+        z = self.direction / length
+        x, y = pr.plane_basis_from_normal(z)
+        R = np.column_stack((x, y, z))
+        return length, pt.transform_from(R, self.start)
+
+    def _add_to_scene(self):
+        length, A2B = self._pose_and_length()
+        if length < 1e-10:
+            return None
+        mesh = _make_arrow_mesh(length)
+        _set_trimesh_color(mesh, self.c)
+        return self._figure.scene.add_mesh_trimesh(
+            name=self._name,
+            mesh=mesh,
+            wxyz=_wxyz_from_matrix(A2B),
+            position=A2B[:3, 3],
+        )
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        self._figure = figure
+        self._name = figure._next_name("vector")
+        self._handle = self._add_to_scene()
+
+    def set_data(self, start, direction, c=None):
+        """Update data.
+
+        Parameters
+        ----------
+        start : array-like, shape (3,)
+            Start of the vector
+
+        direction : array-like, shape (3,)
+            Direction of the vector
+
+        c : array-like, shape (3,), optional (default: None)
+            A color is represented by 3 values between 0 and 1 indicating
+            red, green, and blue respectively.
+        """
+        self.start = np.asarray(start, dtype=float)
+        self.direction = np.asarray(direction, dtype=float)
+        if c is not None:
+            self.c = c
+        if self._figure is None:
+            return
+        if self._handle is not None:
+            self._handle.remove()
+        self._handle = self._add_to_scene()
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Frame(Artist):
+    """Coordinate frame.
+
+    Parameters
+    ----------
+    A2B : array-like, shape (4, 4)
+        Transform from frame A to frame B
+
+    label : str, optional (default: None)
+        Name of the frame
+
+    s : float, optional (default: 1)
+        Length of basis vectors
+    """
+
+    def __init__(self, A2B, label=None, s=1.0):
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.label = label
+        self.s = s
+        self._handle = None
+        self._label_handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        name = figure._next_name("frame")
+        self._handle = figure.scene.add_frame(
+            name=name,
+            axes_length=self.s,
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+        if self.label is not None:
+            self._label_handle = figure.scene.add_label(
+                name=name + "/label",
+                text=self.label,
+                position=self.A2B[:3, 3],
+            )
+
+    def set_data(self, A2B, label=None):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Transform from frame A to frame B
+
+        label : str, optional (default: None)
+            Name of the frame
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if label is not None:
+            self.label = label
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+        if self._label_handle is not None:
+            self._label_handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+        if self._label_handle is not None:
+            self._label_handle.remove()
+            self._label_handle = None
+
+
+class Trajectory(Artist):
+    """Trajectory of poses.
+
+    Parameters
+    ----------
+    H : array-like, shape (n_steps, 4, 4)
+        Sequence of poses represented by homogeneous matrices
+
+    n_frames : int, optional (default: 10)
+        Number of frames that should be plotted to indicate the rotation
+
+    s : float, optional (default: 1)
+        Scaling of the frames that will be drawn
+
+    c : array-like, shape (3,), optional (default: black)
+        A color is represented by 3 values between 0 and 1 indicating
+        red, green, and blue respectively.
+    """
+
+    def __init__(self, H, n_frames=10, s=1.0, c=(0, 0, 0)):
+        self.H = np.asarray(H, dtype=float)
+        self.n_frames = n_frames
+        self.s = s
+        self.c = c
+
+        self.key_frames = []
+        self.line = Line3D(self.H[:, :3, 3], c)
+
+        self.key_frames_indices = np.linspace(
+            0, len(self.H) - 1, self.n_frames, dtype=np.int64
+        )
+        for key_frame_idx in self.key_frames_indices:
+            self.key_frames.append(Frame(self.H[key_frame_idx], s=self.s))
+
+        self.set_data(H)
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        self.line.add_artist(figure)
+        for kf in self.key_frames:
+            kf.add_artist(figure)
+
+    def set_data(self, H):
+        """Update data.
+
+        Parameters
+        ----------
+        H : array-like, shape (n_steps, 4, 4)
+            Sequence of poses represented by homogeneous matrices
+        """
+        self.H = np.asarray(H, dtype=float)
+        self.line.set_data(self.H[:, :3, 3])
+        for i, key_frame_idx in enumerate(self.key_frames_indices):
+            self.key_frames[i].set_data(self.H[key_frame_idx])
+
+    def remove(self):
+        """Remove artist from figure."""
+        self.line.remove()
+        for kf in self.key_frames:
+            kf.remove()
+
+    @property
+    def geometries(self):
+        """Expose geometries.
+
+        Returns
+        -------
+        geometries : list
+            Empty list (viser artists manage their own handles).
+        """
+        return list(
+            chain(
+                self.line.geometries, *[kf.geometries for kf in self.key_frames]
+            )
+        )
+
+
+class Sphere(Artist):
+    """Sphere.
+
+    Parameters
+    ----------
+    radius : float, optional (default: 1)
+        Radius of the sphere
+
+    A2B : array-like, shape (4, 4)
+        Center of the sphere
+
+    resolution : int, optional (default: 20)
+        The resolution of the sphere. The longitudes will be split into
+        resolution segments (i.e. there are resolution + 1 latitude lines
+        including the north and south pole). The latitudes will be split
+        into 2 * resolution segments (i.e. there are 2 * resolution
+        longitude lines.)
+
+    c : array-like, shape (3,), optional (default: None)
+        Color
+    """
+
+    def __init__(self, radius=1.0, A2B=np.eye(4), resolution=20, c=None):
+        self.radius = radius
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.resolution = resolution
+        self.c = c
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        kwargs = dict(
+            name=figure._next_name("sphere"),
+            radius=self.radius,
+            subdivisions=max(1, self.resolution // 6),
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+        if self.c is not None:
+            kwargs["color"] = _to_viser_color(self.c)
+        self._handle = figure.scene.add_icosphere(**kwargs)
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Center of the sphere.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Box(Artist):
+    """Box.
+
+    Parameters
+    ----------
+    size : array-like, shape (3,), optional (default: [1, 1, 1])
+        Size of the box per dimension
+
+    A2B : array-like, shape (4, 4), optional (default: I)
+        Center of the box
+
+    c : array-like, shape (3,), optional (default: None)
+        Color
+    """
+
+    def __init__(self, size=np.ones(3), A2B=np.eye(4), c=None):
+        self.size = np.asarray(size, dtype=float)
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.c = c
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        kwargs = dict(
+            name=figure._next_name("box"),
+            dimensions=tuple(self.size),
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+        if self.c is not None:
+            kwargs["color"] = _to_viser_color(self.c)
+        self._handle = figure.scene.add_box(**kwargs)
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Center of the box.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Cylinder(Artist):
+    """Cylinder.
+
+    A cylinder is the volume covered by a disk moving along a line segment.
+
+    Parameters
+    ----------
+    length : float, optional (default: 1)
+        Length of the cylinder.
+
+    radius : float, optional (default: 1)
+        Radius of the cylinder.
+
+    A2B : array-like, shape (4, 4)
+        Pose of the cylinder. The position corresponds to the center of the
+        line segment and the z-axis to the direction of the line segment.
+
+    resolution : int, optional (default: 20)
+        The circles will be split into resolution segments.
+
+    split : int, optional (default: 4)
+        This parameter is ignored. It is accepted for API compatibility with
+        the Open3D backend.
+
+    c : array-like, shape (3,), optional (default: None)
+        Color
+    """
+
+    def __init__(
+        self,
+        length=2.0,
+        radius=1.0,
+        A2B=np.eye(4),
+        resolution=20,
+        split=4,
+        c=None,
+    ):
+        self.length = length
+        self.radius = radius
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.resolution = resolution
+        self.c = c
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        mesh = trimesh.creation.cylinder(
+            radius=self.radius,
+            height=self.length,
+            sections=self.resolution,
+        )
+        _set_trimesh_color(mesh, self.c)
+        self._handle = figure.scene.add_mesh_trimesh(
+            name=figure._next_name("cylinder"),
+            mesh=mesh,
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Center of the cylinder.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Mesh(Artist):
+    """Mesh.
+
+    Parameters
+    ----------
+    filename : str
+        Path to mesh file
+
+    A2B : array-like, shape (4, 4)
+        Center of the mesh
+
+    s : array-like, shape (3,), optional (default: [1, 1, 1])
+        Scaling of the mesh that will be drawn
+
+    c : array-like, shape (n_vertices, 3) or (3,), optional (default: None)
+        Color(s)
+
+    convex_hull : bool, optional (default: False)
+        Compute convex hull of mesh.
+    """
+
+    def __init__(
+        self, filename, A2B=np.eye(4), s=np.ones(3), c=None, convex_hull=False
+    ):
+        self.filename = filename
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.s = np.asarray(s, dtype=float)
+        self.c = c
+        self.convex_hull = convex_hull
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        mesh = trimesh.load(self.filename)
+        if not isinstance(mesh, trimesh.Trimesh):
+            mesh = trimesh.util.concatenate(list(mesh.geometry.values()))
+        mesh.apply_scale(self.s)
+        if self.convex_hull:
+            mesh = mesh.convex_hull
+        if self.c is not None:
+            _set_trimesh_color(mesh, np.asarray(self.c).ravel()[:3])
+        self._handle = figure.scene.add_mesh_trimesh(
+            name=figure._next_name("mesh"),
+            mesh=mesh,
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Center of the mesh.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Ellipsoid(Artist):
+    """Ellipsoid.
+
+    Parameters
+    ----------
+    radii : array-like, shape (3,)
+        Radii along the x-axis, y-axis, and z-axis of the ellipsoid.
+
+    A2B : array-like, shape (4, 4)
+        Pose of the ellipsoid.
+
+    resolution : int, optional (default: 20)
+        The resolution of the ellipsoid. The longitudes will be split into
+        resolution segments (i.e. there are resolution + 1 latitude lines
+        including the north and south pole). The latitudes will be split
+        into 2 * resolution segments (i.e. there are 2 * resolution
+        longitude lines.)
+
+    c : array-like, shape (3,), optional (default: None)
+        Color
+    """
+
+    def __init__(self, radii, A2B=np.eye(4), resolution=20, c=None):
+        self.radii = np.asarray(radii, dtype=float)
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.resolution = resolution
+        self.c = c
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        mesh = trimesh.creation.icosphere(
+            subdivisions=max(1, self.resolution // 6), radius=1.0
+        )
+        mesh.vertices = mesh.vertices * self.radii[np.newaxis]
+        _set_trimesh_color(mesh, self.c)
+        self._handle = figure.scene.add_mesh_trimesh(
+            name=figure._next_name("ellipsoid"),
+            mesh=mesh,
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Center of the ellipsoid.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Capsule(Artist):
+    """Capsule.
+
+    A capsule is the volume covered by a sphere moving along a line segment.
+
+    Parameters
+    ----------
+    height : float, optional (default: 1)
+        Height of the capsule along its z-axis.
+
+    radius : float, optional (default: 1)
+        Radius of the capsule.
+
+    A2B : array-like, shape (4, 4)
+        Pose of the capsule. The position corresponds to the center of the line
+        segment and the z-axis to the direction of the line segment.
+
+    resolution : int, optional (default: 20)
+        The resolution of the half spheres. The longitudes will be split into
+        resolution segments (i.e. there are resolution + 1 latitude lines
+        including the north and south pole). The latitudes will be split
+        into 2 * resolution segments (i.e. there are 2 * resolution
+        longitude lines.)
+
+    c : array-like, shape (3,), optional (default: None)
+        Color
+    """
+
+    def __init__(
+        self, height=1, radius=1, A2B=np.eye(4), resolution=20, c=None
+    ):
+        self.height = height
+        self.radius = radius
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.resolution = resolution
+        self.c = c
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        mesh = trimesh.creation.capsule(
+            radius=self.radius,
+            height=self.height,
+            count=[self.resolution // 2, self.resolution],
+        )
+        _set_trimesh_color(mesh, self.c)
+        self._handle = figure.scene.add_mesh_trimesh(
+            name=figure._next_name("capsule"),
+            mesh=mesh,
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Start of the capsule's line segment.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Cone(Artist):
+    """Cone.
+
+    Parameters
+    ----------
+    height : float, optional (default: 1)
+        Height of the cone along its z-axis.
+
+    radius : float, optional (default: 1)
+        Radius of the cone.
+
+    A2B : array-like, shape (4, 4)
+        Pose of the cone, which is the center of its circle.
+
+    resolution : int, optional (default: 20)
+        The circle will be split into resolution segments.
+
+    c : array-like, shape (3,), optional (default: None)
+        Color
+    """
+
+    def __init__(
+        self, height=1, radius=1, A2B=np.eye(4), resolution=20, c=None
+    ):
+        self.height = height
+        self.radius = radius
+        self.A2B = np.asarray(A2B, dtype=float)
+        self.resolution = resolution
+        self.c = c
+        self._handle = None
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        mesh = trimesh.creation.cone(
+            radius=self.radius,
+            height=self.height,
+            sections=self.resolution,
+        )
+        _set_trimesh_color(mesh, self.c)
+        self._handle = figure.scene.add_mesh_trimesh(
+            name=figure._next_name("cone"),
+            mesh=mesh,
+            wxyz=_wxyz_from_matrix(self.A2B),
+            position=self.A2B[:3, 3],
+        )
+
+    def set_data(self, A2B):
+        """Update data.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Center of the cone's circle.
+        """
+        self.A2B = np.asarray(A2B, dtype=float)
+        if self._handle is None:
+            return
+        self._handle.wxyz = _wxyz_from_matrix(self.A2B)
+        self._handle.position = self.A2B[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Plane(Artist):
+    """Plane.
+
+    The plane will be defined either by a normal and a point in the plane or
+    by the Hesse normal form, which only needs a normal and the distance to
+    the origin from which we can compute the point in the plane as d * normal.
+
+    A plane will be visualized by a square.
+
+    Parameters
+    ----------
+    normal : array-like, shape (3,), optional (default: [0, 0, 1])
+        Plane normal.
+
+    d : float, optional (default: None)
+        Distance to origin in Hesse normal form.
+
+    point_in_plane : array-like, shape (3,), optional (default: None)
+        Point in plane.
+
+    s : float, optional (default: 1)
+        Scaling of the plane that will be drawn.
+
+    c : array-like, shape (3,), optional (default: None)
+        Color.
+    """
+
+    def __init__(
+        self,
+        normal=np.array([0.0, 0.0, 1.0]),
+        d=None,
+        point_in_plane=None,
+        s=1.0,
+        c=None,
+    ):
+        self.normal = np.asarray(normal, dtype=float)
+        self.d = d
+        self.point_in_plane = (
+            None
+            if point_in_plane is None
+            else np.asarray(point_in_plane, dtype=float)
+        )
+        self.s = s
+        self.c = c
+        self._handle = None
+        self._figure = None
+        self._name = None
+
+    @staticmethod
+    def _resolve_point(normal, d, point_in_plane):
+        if point_in_plane is not None:
+            return np.asarray(point_in_plane, dtype=float)
+        if d is None:
+            raise ValueError(
+                "Either 'd' or 'point_in_plane' has to be defined!"
+            )
+        return d * np.asarray(normal, dtype=float)
+
+    def _make_mesh(self):
+        point = self._resolve_point(self.normal, self.d, self.point_in_plane)
+        x_axis, y_axis = pr.plane_basis_from_normal(self.normal)
+        vertices = np.array(
+            [
+                point + self.s * x_axis + self.s * y_axis,
+                point - self.s * x_axis + self.s * y_axis,
+                point + self.s * x_axis - self.s * y_axis,
+                point - self.s * x_axis - self.s * y_axis,
+            ],
+            dtype=np.float32,
+        )
+        faces = np.array(
+            [[0, 1, 2], [1, 3, 2], [2, 1, 0], [2, 3, 1]], dtype=np.int32
+        )
+        return vertices, faces
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        self._figure = figure
+        self._name = figure._next_name("plane")
+        vertices, faces = self._make_mesh()
+        kwargs = dict(
+            name=self._name, vertices=vertices, faces=faces, side="double"
+        )
+        if self.c is not None:
+            kwargs["color"] = _to_viser_color(self.c)
+        self._handle = figure.scene.add_mesh_simple(**kwargs)
+
+    def set_data(self, normal, d=None, point_in_plane=None, s=None, c=None):
+        """Update data.
+
+        Parameters
+        ----------
+        normal : array-like, shape (3,)
+            Plane normal.
+
+        d : float, optional (default: None)
+            Distance to origin in Hesse normal form.
+
+        point_in_plane : array-like, shape (3,), optional (default: None)
+            Point in plane.
+
+        s : float, optional (default: None)
+            Scaling of the plane that will be drawn.
+
+        c : array-like, shape (3,), optional (default: None)
+            Color.
+
+        Raises
+        ------
+        ValueError
+            If neither 'd' nor 'point_in_plane' is defined.
+        """
+        self.normal = np.asarray(normal, dtype=float)
+        self.d = d
+        self.point_in_plane = (
+            None
+            if point_in_plane is None
+            else np.asarray(point_in_plane, dtype=float)
+        )
+        if s is not None:
+            self.s = s
+        if c is not None:
+            self.c = c
+        if self._figure is None:
+            return
+        if self._handle is not None:
+            self._handle.remove()
+        vertices, faces = self._make_mesh()
+        kwargs = dict(
+            name=self._name, vertices=vertices, faces=faces, side="double"
+        )
+        if self.c is not None:
+            kwargs["color"] = _to_viser_color(self.c)
+        self._handle = self._figure.scene.add_mesh_simple(**kwargs)
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Camera(Artist):
+    """Camera.
+
+    Parameters
+    ----------
+    M : array-like, shape (3, 3)
+        Intrinsic camera matrix that contains the focal lengths on the diagonal
+        and the center of the the image in the last column. It does not matter
+        whether values are given in meters or pixels as long as the unit is the
+        same as for the sensor size.
+
+    cam2world : array-like, shape (4, 4), optional (default: I)
+        Transformation matrix of camera in world frame. We assume that the
+        position is given in meters.
+
+    virtual_image_distance : float, optional (default: 1)
+        Distance from pinhole to virtual image plane that will be displayed.
+        We assume that this distance is given in meters. The unit has to be
+        consistent with the unit of the position in cam2world.
+
+    sensor_size : array-like, shape (2,), optional (default: [1920, 1080])
+        Size of the image sensor: (width, height). It does not matter whether
+        values are given in meters or pixels as long as the unit is the same as
+        for the sensor size.
+
+    strict_check : bool, optional (default: True)
+        Raise a ValueError if the transformation matrix is not numerically
+        close enough to a real transformation matrix. Otherwise we print a
+        warning.
+    """
+
+    def __init__(
+        self,
+        M,
+        cam2world=None,
+        virtual_image_distance=1,
+        sensor_size=(1920, 1080),
+        strict_check=True,
+    ):
+        self.M = np.asarray(M, dtype=float)
+        self.cam2world = (
+            np.eye(4)
+            if cam2world is None
+            else np.asarray(cam2world, dtype=float)
+        )
+        self.cam2world = pt.check_transform(
+            self.cam2world, strict_check=strict_check
+        )
+        self.virtual_image_distance = virtual_image_distance
+        self.sensor_size = sensor_size
+        self.strict_check = strict_check
+        self._handle = None
+
+    def _fov_and_aspect(self):
+        fy = self.M[1, 1]
+        h = self.sensor_size[1]
+        w = self.sensor_size[0]
+        fov = 2.0 * np.arctan(h / (2.0 * fy))
+        aspect = float(w) / float(h)
+        return fov, aspect
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        fov, aspect = self._fov_and_aspect()
+        self._handle = figure.scene.add_camera_frustum(
+            name=figure._next_name("camera"),
+            fov=fov,
+            aspect=aspect,
+            scale=self.virtual_image_distance,
+            wxyz=_wxyz_from_matrix(self.cam2world),
+            position=self.cam2world[:3, 3],
+        )
+
+    def set_data(
+        self,
+        M=None,
+        cam2world=None,
+        virtual_image_distance=None,
+        sensor_size=None,
+    ):
+        """Update camera parameters.
+
+        Parameters
+        ----------
+        M : array-like, shape (3, 3), optional (default: old value)
+            Intrinsic camera matrix that contains the focal lengths on the
+            diagonal and the center of the the image in the last column. It
+            does not matter whether values are given in meters or pixels as
+            long as the unit is the same as for the sensor size.
+
+        cam2world : array-like, shape (4, 4), optional (default: old value)
+            Transformation matrix of camera in world frame. We assume that
+            the position is given in meters.
+
+        virtual_image_distance : float, optional (default: old value)
+            Distance from pinhole to virtual image plane that will be
+            displayed. We assume that this distance is given in meters.
+            The unit has to be consistent with the unit of the position
+            in cam2world.
+
+        sensor_size : array-like, shape (2,), optional (default: old value)
+            Size of the image sensor: (width, height). It does not matter
+            whether values are given in meters or pixels as long as the
+            unit is the same as for the sensor size.
+        """
+        if M is not None:
+            self.M = np.asarray(M, dtype=float)
+        if cam2world is not None:
+            self.cam2world = pt.check_transform(
+                cam2world, strict_check=self.strict_check
+            )
+        if virtual_image_distance is not None:
+            self.virtual_image_distance = virtual_image_distance
+        if sensor_size is not None:
+            self.sensor_size = sensor_size
+        if self._handle is None:
+            return
+        fov, aspect = self._fov_and_aspect()
+        self._handle.fov = fov
+        self._handle.aspect = aspect
+        self._handle.scale = self.virtual_image_distance
+        self._handle.wxyz = _wxyz_from_matrix(self.cam2world)
+        self._handle.position = self.cam2world[:3, 3]
+
+    def remove(self):
+        """Remove artist from figure."""
+        if self._handle is not None:
+            self._handle.remove()
+            self._handle = None
+
+
+class Graph(Artist):
+    """Graph of connected frames.
+
+    Parameters
+    ----------
+    tm : TransformManager
+        Representation of the graph
+
+    frame : str
+        Name of the base frame in which the graph will be displayed
+
+    show_frames : bool, optional (default: False)
+        Show coordinate frames
+
+    show_connections : bool, optional (default: False)
+        Draw lines between frames of the graph
+
+    show_visuals : bool, optional (default: False)
+        Show visuals that are stored in the graph
+
+    show_collision_objects : bool, optional (default: False)
+        Show collision objects that are stored in the graph
+
+    show_name : bool, optional (default: False)
+        Show names of frames
+
+    whitelist : list, optional (default: all)
+        List of frames that should be displayed
+
+    convex_hull_of_collision_objects : bool, optional (default: False)
+        Show convex hull of collision objects.
+
+    s : float, optional (default: 1)
+        Scaling of the frames that will be drawn
+    """
+
+    def __init__(
+        self,
+        tm,
+        frame,
+        show_frames=False,
+        show_connections=False,
+        show_visuals=False,
+        show_collision_objects=False,
+        show_name=False,
+        whitelist=None,
+        convex_hull_of_collision_objects=False,
+        s=1.0,
+    ):
+        self.tm = tm
+        self.frame = frame
+        self.show_frames = show_frames
+        self.show_connections = show_connections
+        self.show_visuals = show_visuals
+        self.show_collision_objects = show_collision_objects
+        self.whitelist = whitelist
+        self.convex_hull_of_collision_objects = convex_hull_of_collision_objects
+        self.s = s
+
+        if self.frame not in self.tm.nodes:
+            raise KeyError("Unknown frame '%s'" % self.frame)
+
+        self.nodes = list(sorted(self.tm._whitelisted_nodes(whitelist)))
+
+        self.frames = {}
+        if self.show_frames:
+            for node in self.nodes:
+                try:
+                    node2frame = self.tm.get_transform(node, frame)
+                    node_name = node if show_name else None
+                    self.frames[node] = Frame(node2frame, node_name, self.s)
+                except KeyError:
+                    pass
+
+        self.connections = {}
+        if self.show_connections:
+            for frame_names in self.tm.transforms.keys():
+                from_frame, to_frame = frame_names
+                if from_frame in self.tm.nodes and to_frame in self.tm.nodes:
+                    try:
+                        self.tm.get_transform(from_frame, self.frame)
+                        self.tm.get_transform(to_frame, self.frame)
+                        self.connections[frame_names] = Line3D(np.zeros((2, 3)))
+                    except KeyError:
+                        pass
+
+        self.visuals = {}
+        if show_visuals and hasattr(self.tm, "visuals"):
+            self.visuals.update(_objects_to_artists(self.tm.visuals))
+        self.collision_objects = {}
+        if show_collision_objects and hasattr(self.tm, "collision_objects"):
+            self.collision_objects.update(
+                _objects_to_artists(
+                    self.tm.collision_objects, convex_hull_of_collision_objects
+                )
+            )
+
+        self.set_data()
+
+    def add_artist(self, figure):
+        """Add artist to figure.
+
+        Parameters
+        ----------
+        figure : Figure
+            Figure to which the artist will be added.
+        """
+        for f in self.frames.values():
+            f.add_artist(figure)
+        for conn in self.connections.values():
+            conn.add_artist(figure)
+        for obj in self.visuals.values():
+            obj.add_artist(figure)
+        for obj in self.collision_objects.values():
+            obj.add_artist(figure)
+
+    def set_data(self):
+        """Indicate that data has been updated."""
+        if self.show_frames:
+            for node in self.nodes:
+                try:
+                    node2frame = self.tm.get_transform(node, self.frame)
+                    self.frames[node].set_data(node2frame)
+                except KeyError:
+                    pass
+
+        if self.show_connections:
+            for frame_names, conn in self.connections.items():
+                from_frame, to_frame = frame_names
+                try:
+                    from2ref = self.tm.get_transform(from_frame, self.frame)
+                    to2ref = self.tm.get_transform(to_frame, self.frame)
+                    points = np.vstack((from2ref[:3, 3], to2ref[:3, 3]))
+                    conn.set_data(points)
+                except KeyError:
+                    pass
+
+        for frame_name, obj in self.visuals.items():
+            A2B = self.tm.get_transform(frame_name, self.frame)
+            obj.set_data(A2B)
+
+        for frame_name, obj in self.collision_objects.items():
+            A2B = self.tm.get_transform(frame_name, self.frame)
+            obj.set_data(A2B)
+
+    def remove(self):
+        """Remove artist from figure."""
+        for f in self.frames.values():
+            f.remove()
+        for conn in self.connections.values():
+            conn.remove()
+        for obj in self.visuals.values():
+            obj.remove()
+        for obj in self.collision_objects.values():
+            obj.remove()
+
+
+def _objects_to_artists(objects, convex_hull=False):
+    """Convert geometries from URDF to artists.
+
+    Parameters
+    ----------
+    objects : list of Geometry
+        Objects parsed from URDF.
+
+    convex_hull : bool, optional (default: False)
+        Compute convex hull for each object.
+
+    Returns
+    -------
+    artists : dict
+        Mapping from frame names to artists.
+    """
+    artists = {}
+    for obj in objects:
+        if obj.color is None:
+            color = None
+        else:
+            # alpha channel is not used
+            color = (obj.color[0], obj.color[1], obj.color[2])
+        try:
+            if isinstance(obj, urdf.Sphere):
+                artist = Sphere(radius=obj.radius, c=color)
+            elif isinstance(obj, urdf.Box):
+                artist = Box(obj.size, c=color)
+            elif isinstance(obj, urdf.Cylinder):
+                artist = Cylinder(obj.length, obj.radius, c=color)
+            else:
+                assert isinstance(obj, urdf.Mesh)
+                artist = Mesh(
+                    obj.filename, s=obj.scale, c=color, convex_hull=convex_hull
+                )
+            artists[obj.frame] = artist
+        except RuntimeError as e:
+            warnings.warn(str(e), RuntimeWarning, stacklevel=1)
+    return artists

--- a/pytransform3d/viser/_artists.py
+++ b/pytransform3d/viser/_artists.py
@@ -405,6 +405,7 @@ class Frame(Artist):
         self._handle = figure.scene.add_frame(
             name=name,
             axes_length=self.s,
+            axes_radius=self.s / 20.0,
             wxyz=_wxyz_from_matrix(self.A2B),
             position=self.A2B[:3, 3],
         )

--- a/pytransform3d/viser/_artists.py
+++ b/pytransform3d/viser/_artists.py
@@ -1309,9 +1309,7 @@ class Camera(Artist):
             (6, 7),
             (7, 5),
         ]
-        return np.array(
-            [[pts[i], pts[j]] for i, j in pairs], dtype=np.float32
-        )
+        return np.array([[pts[i], pts[j]] for i, j in pairs], dtype=np.float32)
 
     def add_artist(self, figure):
         """Add artist to figure.

--- a/pytransform3d/viser/_artists.pyi
+++ b/pytransform3d/viser/_artists.pyi
@@ -1,0 +1,191 @@
+import typing
+from typing import Dict, List, Union
+
+import numpy.typing as npt
+
+from ..transform_manager import TransformManager
+
+if typing.TYPE_CHECKING:
+    from ._figure import Figure
+
+class Artist:
+    def add_artist(self, figure: "Figure") -> None: ...
+    def remove(self) -> None: ...
+    @property
+    def geometries(self) -> List: ...
+
+class Line3D(Artist):
+    def __init__(self, P: npt.ArrayLike, c: npt.ArrayLike = ...): ...
+    def set_data(
+        self, P: npt.ArrayLike, c: Union[None, npt.ArrayLike] = ...
+    ) -> None: ...
+
+class PointCollection3D(Artist):
+    def __init__(
+        self,
+        P: npt.ArrayLike,
+        s: float = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, P: npt.ArrayLike) -> None: ...
+
+class Vector3D(Artist):
+    def __init__(
+        self,
+        start: npt.ArrayLike = ...,
+        direction: npt.ArrayLike = ...,
+        c: npt.ArrayLike = ...,
+    ): ...
+    def set_data(
+        self,
+        start: npt.ArrayLike,
+        direction: npt.ArrayLike,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> None: ...
+
+class Frame(Artist):
+    def __init__(
+        self, A2B: npt.ArrayLike, label: Union[None, str] = ..., s: float = ...
+    ): ...
+    def set_data(
+        self, A2B: npt.ArrayLike, label: Union[None, str] = ...
+    ) -> None: ...
+
+class Trajectory(Artist):
+    def __init__(
+        self,
+        H: npt.ArrayLike,
+        n_frames: int = ...,
+        s: float = ...,
+        c: npt.ArrayLike = ...,
+    ): ...
+    def set_data(self, H: npt.ArrayLike) -> None: ...
+
+class Sphere(Artist):
+    def __init__(
+        self,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Box(Artist):
+    def __init__(
+        self,
+        size: npt.ArrayLike = ...,
+        A2B: npt.ArrayLike = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Cylinder(Artist):
+    def __init__(
+        self,
+        length: float = ...,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        split: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Mesh(Artist):
+    def __init__(
+        self,
+        filename: str,
+        A2B: npt.ArrayLike = ...,
+        s: npt.ArrayLike = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+        convex_hull: bool = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Ellipsoid(Artist):
+    def __init__(
+        self,
+        radii: npt.ArrayLike,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Capsule(Artist):
+    def __init__(
+        self,
+        height: float = ...,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Cone(Artist):
+    def __init__(
+        self,
+        height: float = ...,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(self, A2B: npt.ArrayLike) -> None: ...
+
+class Plane(Artist):
+    def __init__(
+        self,
+        normal: npt.ArrayLike = ...,
+        d: Union[None, float] = ...,
+        point_in_plane: Union[None, npt.ArrayLike] = ...,
+        s: float = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ): ...
+    def set_data(
+        self,
+        normal: npt.ArrayLike,
+        d: Union[None, float] = ...,
+        point_in_plane: Union[None, npt.ArrayLike] = ...,
+        s: Union[None, float] = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> None: ...
+
+class Camera(Artist):
+    def __init__(
+        self,
+        M: npt.ArrayLike,
+        cam2world: Union[None, npt.ArrayLike] = ...,
+        virtual_image_distance: float = ...,
+        sensor_size: npt.ArrayLike = ...,
+        strict_check: bool = ...,
+    ): ...
+    def set_data(
+        self,
+        M: Union[None, npt.ArrayLike] = ...,
+        cam2world: Union[None, npt.ArrayLike] = ...,
+        virtual_image_distance: Union[None, float] = ...,
+        sensor_size: Union[None, npt.ArrayLike] = ...,
+    ) -> None: ...
+
+class Graph(Artist):
+    def __init__(
+        self,
+        tm: TransformManager,
+        frame: str,
+        show_frames: bool = ...,
+        show_connections: bool = ...,
+        show_visuals: bool = ...,
+        show_collision_objects: bool = ...,
+        show_name: bool = ...,
+        whitelist: Union[None, List[str]] = ...,
+        convex_hull_of_collision_objects: bool = ...,
+        s: float = ...,
+    ): ...
+    def set_data(self) -> None: ...
+
+def _objects_to_artists(
+    objects: list, convex_hull: bool = ...
+) -> Dict[str, Artist]: ...

--- a/pytransform3d/viser/_figure.py
+++ b/pytransform3d/viser/_figure.py
@@ -146,10 +146,13 @@ class Figure:
         Parameters
         ----------
         azim : float, optional (default: -60)
-            Azimuth angle in the x,y plane in degrees.
+            Azimuth angle around the world-up axis (y) in degrees. 0 places
+            the camera on the +z side of *center*; 90 places it on the +x
+            side.
 
         elev : float, optional (default: 30)
-            Elevation angle in the z plane in degrees.
+            Elevation angle above the ground plane (x-z) in degrees. 0 is
+            level; 90 is directly above *center*.
 
         center : array-like, shape (3,), optional (default: [0, 0, 0])
             The point the camera looks at.
@@ -158,8 +161,10 @@ class Figure:
             Distance from *center* to the camera.
         """
         center = np.asarray(center, dtype=float)
-        R_azim = pr.active_matrix_from_angle(2, np.deg2rad(azim))
-        R_elev = pr.active_matrix_from_angle(1, np.deg2rad(-elev))
+        # viser uses a y-up coordinate system. Azimuth rotates around the
+        # y-axis (world up); elevation tilts from the x-z ground plane.
+        R_azim = pr.active_matrix_from_angle(1, np.deg2rad(azim))
+        R_elev = pr.active_matrix_from_angle(0, np.deg2rad(-elev))
         R = R_azim.dot(R_elev)
         position = center + R.dot(np.array([0.0, 0.0, distance]))
         wxyz = pr.quaternion_from_matrix(R, strict_check=False)

--- a/pytransform3d/viser/_figure.py
+++ b/pytransform3d/viser/_figure.py
@@ -720,23 +720,78 @@ class Figure:
     def save_image(self, filename):
         """Save rendered image to file.
 
-        Note: this method is not supported by the viser backend. Viser is
-        browser-based and does not provide server-side screenshot capture.
+        Launches a headless Chromium browser via Playwright, connects it to
+        the viser server, waits for the scene to render, and saves the result.
+
+        Requires ``playwright`` and ``imageio``::
+
+            pip install playwright imageio
+            playwright install chromium
 
         Parameters
         ----------
         filename : str
             Path to file in which the rendered image should be stored.
+            The extension determines the format (e.g. ``.jpg``, ``.png``).
 
         Raises
         ------
-        NotImplementedError
-            Always, because viser does not support server-side screenshots.
+        ImportError
+            If ``playwright`` or ``imageio`` are not installed.
+        RuntimeError
+            If no browser client connects within the timeout.
         """
-        raise NotImplementedError(
-            "save_image() is not supported by the viser backend. "
-            "Use your browser's screenshot functionality instead."
-        )
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise ImportError(
+                "save_image() requires playwright. "
+                "Install with: pip install playwright "
+                "&& playwright install chromium"
+            ) from exc
+        try:
+            import imageio
+        except ImportError as exc:
+            raise ImportError(
+                "save_image() requires imageio: pip install imageio"
+            ) from exc
+
+        port = self._server.get_port()
+        url = f"http://localhost:{port}"
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(
+                headless=True,
+                args=[
+                    "--use-gl=swiftshader",
+                    "--no-sandbox",
+                    "--disable-dev-shm-usage",
+                ],
+            )
+            page = browser.new_page(viewport={"width": 1280, "height": 720})
+            page.goto(url)
+
+            # Poll until the browser's WebSocket client registers.
+            timeout = 10.0
+            start = time.time()
+            while not self._server.get_clients():
+                if time.time() - start > timeout:
+                    browser.close()
+                    raise RuntimeError(
+                        "Viser browser client did not connect within "
+                        f"{timeout:.0f} s."
+                    )
+                time.sleep(0.1)
+
+            # Allow extra time for Three.js to process all scene messages.
+            page.wait_for_timeout(3000)
+
+            client = next(iter(self._server.get_clients().values()))
+            image = client.get_render(
+                height=720, width=1280, transport_format="jpeg"
+            )
+            imageio.imwrite(filename, image)
+            browser.close()
 
     def show(self):
         """Print the URL to open in a browser.

--- a/pytransform3d/viser/_figure.py
+++ b/pytransform3d/viser/_figure.py
@@ -135,8 +135,13 @@ class Figure:
                 time.sleep(1.0 / 30.0)
             initialized = True
 
-    def view_init(self, azim=-60, elev=30):
-        """Set the elevation and azimuth of the axes for all connected clients.
+    def view_init(
+        self, azim=-60, elev=30, center=(0.0, 0.0, 0.0), distance=5.0
+    ):
+        """Set the initial camera pose for all current and future clients.
+
+        The callback registered here fires for every new browser connection, so
+        the view is consistent regardless of when the browser is opened.
 
         Parameters
         ----------
@@ -144,17 +149,26 @@ class Figure:
             Azimuth angle in the x,y plane in degrees.
 
         elev : float, optional (default: 30)
-            Elevation angle in the z plane.
+            Elevation angle in the z plane in degrees.
+
+        center : array-like, shape (3,), optional (default: [0, 0, 0])
+            The point the camera looks at.
+
+        distance : float, optional (default: 5)
+            Distance from *center* to the camera.
         """
+        center = np.asarray(center, dtype=float)
         R_azim = pr.active_matrix_from_angle(2, np.deg2rad(azim))
         R_elev = pr.active_matrix_from_angle(1, np.deg2rad(-elev))
         R = R_azim.dot(R_elev)
-        distance = 5.0
-        position = R.dot(np.array([0.0, 0.0, distance]))
+        position = center + R.dot(np.array([0.0, 0.0, distance]))
         wxyz = pr.quaternion_from_matrix(R, strict_check=False)
-        for _, client in self._server.get_clients().items():
+
+        @self._server.on_client_connect
+        def _set_camera(client):
             client.camera.position = position
             client.camera.wxyz = wxyz
+            client.camera.look_at = center
 
     def plot(self, P, c=(0, 0, 0)):
         """Plot line.

--- a/pytransform3d/viser/_figure.py
+++ b/pytransform3d/viser/_figure.py
@@ -1,0 +1,748 @@
+"""Figure based on viser."""
+
+import time
+import warnings
+
+import numpy as np
+import viser
+
+from ._artists import (
+    Line3D,
+    PointCollection3D,
+    Vector3D,
+    Frame,
+    Trajectory,
+    Camera,
+    Box,
+    Sphere,
+    Cylinder,
+    Mesh,
+    Ellipsoid,
+    Capsule,
+    Cone,
+    Plane,
+    Graph,
+)
+from .. import rotations as pr
+from .. import trajectories as ptr
+from .. import transformations as pt
+
+
+class Figure:
+    """The top level container for all the plot elements.
+
+    The figure starts a local web server. Open the printed URL in a browser
+    to view the scene. Call :func:`show` to print the URL.
+
+    Parameters
+    ----------
+    window_name : str, optional (default: pytransform3d)
+        Label shown at the top of the GUI panel in the browser.
+
+    port : int, optional (default: 8080)
+        Port used by the viser web server.
+    """
+
+    def __init__(self, window_name="pytransform3d", port=8080):
+        self._server = viser.ViserServer(label=window_name, port=port)
+        self.scene = self._server.scene
+        self.scene.configure_default_lights()
+        self.scene.add_grid(name="/_grid", width=10, height=10)
+        self._object_count = 0
+
+    def _next_name(self, prefix):
+        name = "/%s/%05d" % (prefix, self._object_count)
+        self._object_count += 1
+        return name
+
+    def remove_artist(self, artist):
+        """Remove artist from the scene.
+
+        Parameters
+        ----------
+        artist : Artist
+            Artist that should be removed from this figure.
+        """
+        artist.remove()
+
+    def set_line_width(self, line_width):
+        """Set render option line width.
+
+        Note: this setting is not effective after line segments have been
+        added to the scene.
+
+        Parameters
+        ----------
+        line_width : float
+            Line width.
+        """
+        warnings.warn(
+            "set_line_width() has no effect in the viser backend. Pass "
+            "line_width when creating the artist.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    def set_zoom(self, zoom):
+        """Set zoom for all connected clients.
+
+        Parameters
+        ----------
+        zoom : float
+            Zoom factor. Values greater than 1 zoom in, less than 1 zoom out.
+        """
+        for _, client in self._server.get_clients().items():
+            pos = np.asarray(client.camera.position)
+            client.camera.position = pos / zoom
+
+    def animate(self, callback, n_frames, loop=False, fargs=()):
+        """Make animation with callback.
+
+        Parameters
+        ----------
+        callback : callable
+            Callback that will be called in a loop to update geometries.
+            The first input of the function will be the current frame
+            index from [0, `n_frames`). Further arguments can be given as
+            `fargs`. The function should return one artist object or a
+            list of artists that have been updated.
+
+        n_frames : int
+            Total number of frames.
+
+        loop : bool, optional (default: False)
+            Run callback in an infinite loop.
+
+        fargs : list, optional (default: [])
+            Arguments that will be passed to the callback.
+
+        Raises
+        ------
+        RuntimeError
+            When callback does not return any artists.
+        """
+        initialized = False
+        while loop or not initialized:
+            for i in range(n_frames):
+                drawn_artists = callback(i, *fargs)
+
+                if drawn_artists is None:
+                    raise RuntimeError(
+                        "The animation function must return a "
+                        "sequence of Artist objects."
+                    )
+
+                time.sleep(1.0 / 30.0)
+            initialized = True
+
+    def view_init(self, azim=-60, elev=30):
+        """Set the elevation and azimuth of the axes for all connected clients.
+
+        Parameters
+        ----------
+        azim : float, optional (default: -60)
+            Azimuth angle in the x,y plane in degrees.
+
+        elev : float, optional (default: 30)
+            Elevation angle in the z plane.
+        """
+        R_azim = pr.active_matrix_from_angle(2, np.deg2rad(azim))
+        R_elev = pr.active_matrix_from_angle(1, np.deg2rad(-elev))
+        R = R_azim.dot(R_elev)
+        distance = 5.0
+        position = R.dot(np.array([0.0, 0.0, distance]))
+        wxyz = pr.quaternion_from_matrix(R, strict_check=False)
+        for _, client in self._server.get_clients().items():
+            client.camera.position = position
+            client.camera.wxyz = wxyz
+
+    def plot(self, P, c=(0, 0, 0)):
+        """Plot line.
+
+        Parameters
+        ----------
+        P : array-like, shape (n_points, 3)
+            Points of which the line consists.
+
+        c : array-like, shape (n_points - 1, 3) or (3,), optional
+            (default: black). Color can be given as individual colors per
+            line segment or as one color for each segment. A color is
+            represented by 3 values between 0 and 1 indicating red, green,
+            and blue respectively.
+
+        Returns
+        -------
+        line : Line3D
+            New line.
+        """
+        line3d = Line3D(P, c)
+        line3d.add_artist(self)
+        return line3d
+
+    def scatter(self, P, s=0.05, c=None):
+        """Plot collection of points.
+
+        Parameters
+        ----------
+        P : array, shape (n_points, 3)
+            Points
+
+        s : float, optional (default: 0.05)
+            Scaling of the points that will be drawn.
+
+        c : array-like, shape (3,) or (n_points, 3), optional (default: black)
+            A color is represented by 3 values between 0 and 1 indicating
+            red, green, and blue respectively.
+
+        Returns
+        -------
+        point_collection : PointCollection3D
+            New point collection.
+        """
+        point_collection = PointCollection3D(P, s, c)
+        point_collection.add_artist(self)
+        return point_collection
+
+    def plot_vector(
+        self, start=np.zeros(3), direction=np.array([1, 0, 0]), c=(0, 0, 0)
+    ):
+        """Plot vector.
+
+        Parameters
+        ----------
+        start : array-like, shape (3,), optional (default: [0, 0, 0])
+            Start of the vector
+
+        direction : array-like, shape (3,), optional (default: [1, 0, 0])
+            Direction of the vector
+
+        c : array-like, shape (3,), optional (default: black)
+            A color is represented by 3 values between 0 and 1 indicating
+            red, green, and blue respectively.
+
+        Returns
+        -------
+        vector : Vector3D
+            New vector.
+        """
+        vector3d = Vector3D(start, direction, c)
+        vector3d.add_artist(self)
+        return vector3d
+
+    def plot_basis(self, R=None, p=np.zeros(3), s=1.0, strict_check=True):
+        """Plot basis.
+
+        Parameters
+        ----------
+        R : array-like, shape (3, 3), optional (default: I)
+            Rotation matrix, each column contains a basis vector
+
+        p : array-like, shape (3,), optional (default: [0, 0, 0])
+            Offset from the origin
+
+        s : float, optional (default: 1)
+            Scaling of the frame that will be drawn
+
+        strict_check : bool, optional (default: True)
+            Raise a ValueError if the rotation matrix is not numerically
+            close enough to a real rotation matrix. Otherwise we print a
+            warning.
+
+        Returns
+        -------
+        frame : Frame
+            New frame.
+        """
+        if R is None:
+            R = np.eye(3)
+        R = pr.check_matrix(R, strict_check=strict_check)
+
+        frame = Frame(pt.transform_from(R=R, p=p), s=s)
+        frame.add_artist(self)
+        return frame
+
+    def plot_transform(self, A2B=None, s=1.0, name=None, strict_check=True):
+        """Plot coordinate frame.
+
+        Parameters
+        ----------
+        A2B : array-like, shape (4, 4)
+            Transform from frame A to frame B
+
+        s : float, optional (default: 1)
+            Length of basis vectors
+
+        name : str, optional (default: None)
+            Name of the frame
+
+        strict_check : bool, optional (default: True)
+            Raise a ValueError if the transformation matrix is not
+            numerically close enough to a real transformation matrix.
+            Otherwise we print a warning.
+
+        Returns
+        -------
+        frame : Frame
+            New frame.
+        """
+        if A2B is None:
+            A2B = np.eye(4)
+        A2B = pt.check_transform(A2B, strict_check=strict_check)
+
+        frame = Frame(A2B, name, s)
+        frame.add_artist(self)
+        return frame
+
+    def plot_trajectory(self, P, n_frames=10, s=1.0, c=(0, 0, 0)):
+        """Trajectory of poses.
+
+        Parameters
+        ----------
+        P : array-like, shape (n_steps, 7), optional (default: None)
+            Sequence of poses represented by positions and quaternions in
+            the order (x, y, z, w, vx, vy, vz) for each step
+
+        n_frames : int, optional (default: 10)
+            Number of frames that should be plotted to indicate the
+            rotation
+
+        s : float, optional (default: 1)
+            Scaling of the frames that will be drawn
+
+        c : array-like, shape (3,), optional (default: black)
+            A color is represented by 3 values between 0 and 1 indicating
+            red, green, and blue respectively.
+
+        Returns
+        -------
+        trajectory : Trajectory
+            New trajectory.
+        """
+        H = ptr.transforms_from_pqs(P)
+        trajectory = Trajectory(H, n_frames, s, c)
+        trajectory.add_artist(self)
+        return trajectory
+
+    def plot_sphere(self, radius=1.0, A2B=np.eye(4), resolution=20, c=None):
+        """Plot sphere.
+
+        Parameters
+        ----------
+        radius : float, optional (default: 1)
+            Radius of the sphere
+
+        A2B : array-like, shape (4, 4)
+            Transform from frame A to frame B
+
+        resolution : int, optional (default: 20)
+            The resolution of the sphere. The longitudes will be split into
+            resolution segments (i.e. there are resolution + 1 latitude
+            lines including the north and south pole). The latitudes will
+            be split into 2 * resolution segments (i.e. there are
+            2 * resolution longitude lines.)
+
+        c : array-like, shape (3,), optional (default: None)
+            Color
+
+        Returns
+        -------
+        sphere : Sphere
+            New sphere.
+        """
+        sphere = Sphere(radius, A2B, resolution, c)
+        sphere.add_artist(self)
+        return sphere
+
+    def plot_box(self, size=np.ones(3), A2B=np.eye(4), c=None):
+        """Plot box.
+
+        Parameters
+        ----------
+        size : array-like, shape (3,), optional (default: [1, 1, 1])
+            Size of the box per dimension
+
+        A2B : array-like, shape (4, 4), optional (default: I)
+            Center of the box
+
+        c : array-like, shape (3,), optional (default: None)
+            Color
+
+        Returns
+        -------
+        box : Box
+            New box.
+        """
+        box = Box(size, A2B, c)
+        box.add_artist(self)
+        return box
+
+    def plot_cylinder(
+        self,
+        length=2.0,
+        radius=1.0,
+        A2B=np.eye(4),
+        resolution=20,
+        split=4,
+        c=None,
+    ):
+        """Plot cylinder.
+
+        Parameters
+        ----------
+        length : float, optional (default: 1)
+            Length of the cylinder.
+
+        radius : float, optional (default: 1)
+            Radius of the cylinder.
+
+        A2B : array-like, shape (4, 4)
+            Pose of the cylinder. The position corresponds to the center of the
+            line segment and the z-axis to the direction of the line segment.
+
+        resolution : int, optional (default: 20)
+            The circle will be split into resolution segments
+
+        split : int, optional (default: 4)
+            This parameter is ignored. It is accepted for API compatibility
+            with the Open3D backend.
+
+        c : array-like, shape (3,), optional (default: None)
+            Color
+
+        Returns
+        -------
+        cylinder : Cylinder
+            New cylinder.
+        """
+        cylinder = Cylinder(length, radius, A2B, resolution, split, c)
+        cylinder.add_artist(self)
+        return cylinder
+
+    def plot_mesh(self, filename, A2B=np.eye(4), s=np.ones(3), c=None):
+        """Plot mesh.
+
+        Parameters
+        ----------
+        filename : str
+            Path to mesh file
+
+        A2B : array-like, shape (4, 4)
+            Center of the mesh
+
+        s : array-like, shape (3,), optional (default: [1, 1, 1])
+            Scaling of the mesh that will be drawn
+
+        c : array-like, shape (n_vertices, 3) or (3,), optional (default: None)
+            Color(s)
+
+        Returns
+        -------
+        mesh : Mesh
+            New mesh.
+        """
+        mesh = Mesh(filename, A2B, s, c)
+        mesh.add_artist(self)
+        return mesh
+
+    def plot_ellipsoid(
+        self, radii=np.ones(3), A2B=np.eye(4), resolution=20, c=None
+    ):
+        """Plot ellipsoid.
+
+        Parameters
+        ----------
+        radii : array-like, shape (3,)
+            Radii along the x-axis, y-axis, and z-axis of the ellipsoid.
+
+        A2B : array-like, shape (4, 4)
+            Transform from frame A to frame B
+
+        resolution : int, optional (default: 20)
+            The resolution of the ellipsoid. The longitudes will be split into
+            resolution segments (i.e. there are resolution + 1 latitude
+            lines including the north and south pole). The latitudes will
+            be split into 2 * resolution segments (i.e. there are
+            2 * resolution longitude lines.)
+
+        c : array-like, shape (3,), optional (default: None)
+            Color
+
+        Returns
+        -------
+        ellipsoid : Ellipsoid
+            New ellipsoid.
+        """
+        ellipsoid = Ellipsoid(radii, A2B, resolution, c)
+        ellipsoid.add_artist(self)
+        return ellipsoid
+
+    def plot_capsule(
+        self, height=1, radius=1, A2B=np.eye(4), resolution=20, c=None
+    ):
+        """Plot capsule.
+
+        A capsule is the volume covered by a sphere moving along a line
+        segment.
+
+        Parameters
+        ----------
+        height : float, optional (default: 1)
+            Height of the capsule along its z-axis.
+
+        radius : float, optional (default: 1)
+            Radius of the capsule.
+
+        A2B : array-like, shape (4, 4)
+            Pose of the capsule. The position corresponds to the center of the
+            line segment and the z-axis to the direction of the line segment.
+
+        resolution : int, optional (default: 20)
+            The resolution of the capsule. The longitudes will be split into
+            resolution segments (i.e. there are resolution + 1 latitude lines
+            including the north and south pole). The latitudes will be split
+            into 2 * resolution segments (i.e. there are 2 * resolution
+            longitude lines.)
+
+        c : array-like, shape (3,), optional (default: None)
+            Color
+
+        Returns
+        -------
+        capsule : Capsule
+            New capsule.
+        """
+        capsule = Capsule(height, radius, A2B, resolution, c)
+        capsule.add_artist(self)
+        return capsule
+
+    def plot_cone(
+        self, height=1, radius=1, A2B=np.eye(4), resolution=20, c=None
+    ):
+        """Plot cone.
+
+        Parameters
+        ----------
+        height : float, optional (default: 1)
+            Height of the cone along its z-axis.
+
+        radius : float, optional (default: 1)
+            Radius of the cone.
+
+        A2B : array-like, shape (4, 4)
+            Pose of the cone.
+
+        resolution : int, optional (default: 20)
+            The circle will be split into resolution segments.
+
+        c : array-like, shape (3,), optional (default: None)
+            Color
+
+        Returns
+        -------
+        cone : Cone
+            New cone.
+        """
+        cone = Cone(height, radius, A2B, resolution, c)
+        cone.add_artist(self)
+        return cone
+
+    def plot_plane(
+        self,
+        normal=np.array([0.0, 0.0, 1.0]),
+        d=None,
+        point_in_plane=None,
+        s=1.0,
+        c=None,
+    ):
+        """Plot plane.
+
+        Parameters
+        ----------
+        normal : array-like, shape (3,), optional (default: [0, 0, 1])
+            Plane normal.
+
+        d : float, optional (default: None)
+            Distance to origin in Hesse normal form.
+
+        point_in_plane : array-like, shape (3,), optional (default: None)
+            Point in plane.
+
+        s : float, optional (default: 1)
+            Scaling of the plane that will be drawn.
+
+        c : array-like, shape (3,), optional (default: None)
+            Color.
+
+        Returns
+        -------
+        plane : Plane
+            New plane.
+        """
+        plane = Plane(normal, d, point_in_plane, s, c)
+        plane.add_artist(self)
+        return plane
+
+    def plot_graph(
+        self,
+        tm,
+        frame,
+        show_frames=False,
+        show_connections=False,
+        show_visuals=False,
+        show_collision_objects=False,
+        show_name=False,
+        whitelist=None,
+        convex_hull_of_collision_objects=False,
+        s=1.0,
+    ):
+        """Plot graph of connected frames.
+
+        Parameters
+        ----------
+        tm : TransformManager
+            Representation of the graph
+
+        frame : str
+            Name of the base frame in which the graph will be displayed
+
+        show_frames : bool, optional (default: False)
+            Show coordinate frames
+
+        show_connections : bool, optional (default: False)
+            Draw lines between frames of the graph
+
+        show_visuals : bool, optional (default: False)
+            Show visuals that are stored in the graph
+
+        show_collision_objects : bool, optional (default: False)
+            Show collision objects that are stored in the graph
+
+        show_name : bool, optional (default: False)
+            Show names of frames
+
+        whitelist : list, optional (default: all)
+            List of frames that should be displayed
+
+        convex_hull_of_collision_objects : bool, optional (default: False)
+            Show convex hull of collision objects.
+
+        s : float, optional (default: 1)
+            Scaling of the frames that will be drawn
+
+        Returns
+        -------
+        graph : Graph
+            New graph.
+        """
+        graph = Graph(
+            tm,
+            frame,
+            show_frames,
+            show_connections,
+            show_visuals,
+            show_collision_objects,
+            show_name,
+            whitelist,
+            convex_hull_of_collision_objects,
+            s,
+        )
+        graph.add_artist(self)
+        return graph
+
+    def plot_camera(
+        self,
+        M,
+        cam2world=None,
+        virtual_image_distance=1,
+        sensor_size=(1920, 1080),
+        strict_check=True,
+    ):
+        """Plot camera in world coordinates.
+
+        Parameters
+        ----------
+        M : array-like, shape (3, 3)
+            Intrinsic camera matrix that contains the focal lengths on the
+            diagonal and the center of the the image in the last column. It
+            does not matter whether values are given in meters or pixels as
+            long as the unit is the same as for the sensor size.
+
+        cam2world : array-like, shape (4, 4), optional (default: I)
+            Transformation matrix of camera in world frame. We assume that the
+            position is given in meters.
+
+        virtual_image_distance : float, optional (default: 1)
+            Distance from pinhole to virtual image plane that will be
+            displayed. We assume that this distance is given in meters. The
+            unit has to be consistent with the unit of the position in
+            cam2world.
+
+        sensor_size : array-like, shape (2,), optional (default: [1920, 1080])
+            Size of the image sensor: (width, height). It does not matter
+            whether values are given in meters or pixels as long as the unit is
+            the same as for the sensor size.
+
+        strict_check : bool, optional (default: True)
+            Raise a ValueError if the transformation matrix is not numerically
+            close enough to a real transformation matrix. Otherwise we print a
+            warning.
+
+        Returns
+        -------
+        camera : Camera
+            New camera.
+        """
+        camera = Camera(
+            M, cam2world, virtual_image_distance, sensor_size, strict_check
+        )
+        camera.add_artist(self)
+        return camera
+
+    def save_image(self, filename):
+        """Save rendered image to file.
+
+        Note: this method is not supported by the viser backend. Viser is
+        browser-based and does not provide server-side screenshot capture.
+
+        Parameters
+        ----------
+        filename : str
+            Path to file in which the rendered image should be stored.
+
+        Raises
+        ------
+        NotImplementedError
+            Always, because viser does not support server-side screenshots.
+        """
+        raise NotImplementedError(
+            "save_image() is not supported by the viser backend. "
+            "Use your browser's screenshot functionality instead."
+        )
+
+    def show(self):
+        """Print the URL to open in a browser.
+
+        The viser server runs in a background thread and stays alive until
+        the Python process ends or :attr:`_server` is stopped manually.
+        """
+        port = self._server.get_port()
+        print("Open in browser: http://localhost:%d" % port)
+
+
+def figure(window_name="pytransform3d", port=8080):
+    """Create a new figure.
+
+    Parameters
+    ----------
+    window_name : str, optional (default: pytransform3d)
+        Label shown at the top of the GUI panel in the browser.
+
+    port : int, optional (default: 8080)
+        Port used by the viser web server.
+
+    Returns
+    -------
+    figure : Figure
+        New figure.
+    """
+    return Figure(window_name, port)

--- a/pytransform3d/viser/_figure.py
+++ b/pytransform3d/viser/_figure.py
@@ -163,16 +163,16 @@ class Figure:
         center = np.asarray(center, dtype=float)
         # viser uses a y-up coordinate system. Azimuth rotates around the
         # y-axis (world up); elevation tilts from the x-z ground plane.
+        # Only position and look_at are set; viser derives the camera
+        # orientation from those two using y as world-up.
         R_azim = pr.active_matrix_from_angle(1, np.deg2rad(azim))
         R_elev = pr.active_matrix_from_angle(0, np.deg2rad(-elev))
         R = R_azim.dot(R_elev)
         position = center + R.dot(np.array([0.0, 0.0, distance]))
-        wxyz = pr.quaternion_from_matrix(R, strict_check=False)
 
         @self._server.on_client_connect
         def _set_camera(client):
             client.camera.position = position
-            client.camera.wxyz = wxyz
             client.camera.look_at = center
 
     def plot(self, P, c=(0, 0, 0)):

--- a/pytransform3d/viser/_figure.pyi
+++ b/pytransform3d/viser/_figure.pyi
@@ -1,0 +1,160 @@
+from typing import Callable, List, Tuple, Any, Union
+
+import numpy.typing as npt
+
+from ._artists import (
+    Artist,
+    Frame,
+    Trajectory,
+    Sphere,
+    Box,
+    Cylinder,
+    Mesh,
+    Ellipsoid,
+    Capsule,
+    Cone,
+    Plane,
+    Graph,
+    Camera,
+    Line3D,
+    PointCollection3D,
+    Vector3D,
+)
+from ..transform_manager import TransformManager
+
+class Figure:
+    def __init__(
+        self,
+        window_name: str = ...,
+        port: int = ...,
+    ) -> None: ...
+    def remove_artist(self, artist: Artist) -> None: ...
+    def set_line_width(self, line_width: float) -> None: ...
+    def set_zoom(self, zoom: float) -> None: ...
+    def animate(
+        self,
+        callback: Callable,
+        n_frames: int,
+        loop: bool = ...,
+        fargs: Tuple[Any, ...] = ...,
+    ) -> None: ...
+    def view_init(self, azim: float = ..., elev: float = ...) -> None: ...
+    def plot(self, P: npt.ArrayLike, c: npt.ArrayLike = ...) -> Line3D: ...
+    def scatter(
+        self,
+        P: npt.ArrayLike,
+        s: float = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> PointCollection3D: ...
+    def plot_vector(
+        self,
+        start: npt.ArrayLike = ...,
+        direction: npt.ArrayLike = ...,
+        c: npt.ArrayLike = ...,
+    ) -> Vector3D: ...
+    def plot_basis(
+        self,
+        R: Union[None, npt.ArrayLike] = ...,
+        p: npt.ArrayLike = ...,
+        s: float = ...,
+        strict_check: bool = ...,
+    ) -> Frame: ...
+    def plot_transform(
+        self,
+        A2B: Union[None, npt.ArrayLike] = ...,
+        s: float = ...,
+        name: Union[str, None] = ...,
+        strict_check: bool = ...,
+    ) -> Frame: ...
+    def plot_trajectory(
+        self,
+        P: npt.ArrayLike,
+        n_frames: int = ...,
+        s: float = ...,
+        c: npt.ArrayLike = ...,
+    ) -> Trajectory: ...
+    def plot_sphere(
+        self,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Sphere: ...
+    def plot_box(
+        self,
+        size: npt.ArrayLike = ...,
+        A2B: npt.ArrayLike = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Box: ...
+    def plot_cylinder(
+        self,
+        length: float = ...,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        split: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Cylinder: ...
+    def plot_mesh(
+        self,
+        filename: str,
+        A2B: npt.ArrayLike = ...,
+        s: npt.ArrayLike = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Mesh: ...
+    def plot_ellipsoid(
+        self,
+        radii: npt.ArrayLike = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Ellipsoid: ...
+    def plot_capsule(
+        self,
+        height: float = ...,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Capsule: ...
+    def plot_cone(
+        self,
+        height: float = ...,
+        radius: float = ...,
+        A2B: npt.ArrayLike = ...,
+        resolution: int = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Cone: ...
+    def plot_plane(
+        self,
+        normal: npt.ArrayLike = ...,
+        d: Union[None, float] = ...,
+        point_in_plane: Union[None, npt.ArrayLike] = ...,
+        s: float = ...,
+        c: Union[None, npt.ArrayLike] = ...,
+    ) -> Plane: ...
+    def plot_graph(
+        self,
+        tm: TransformManager,
+        frame: str,
+        show_frames: bool = ...,
+        show_connections: bool = ...,
+        show_visuals: bool = ...,
+        show_collision_objects: bool = ...,
+        show_name: bool = ...,
+        whitelist: Union[None, List[str]] = ...,
+        convex_hull_of_collision_objects: bool = ...,
+        s: float = ...,
+    ) -> Graph: ...
+    def plot_camera(
+        self,
+        M: npt.ArrayLike,
+        cam2world: Union[None, npt.ArrayLike] = ...,
+        virtual_image_distance: float = ...,
+        sensor_size: npt.ArrayLike = ...,
+        strict_check: bool = ...,
+    ) -> Camera: ...
+    def save_image(self, filename: str) -> None: ...
+    def show(self) -> None: ...
+
+def figure(window_name: str = ..., port: int = ...) -> Figure: ...

--- a/pytransform3d/viser/_figure.pyi
+++ b/pytransform3d/viser/_figure.pyi
@@ -38,7 +38,13 @@ class Figure:
         loop: bool = ...,
         fargs: Tuple[Any, ...] = ...,
     ) -> None: ...
-    def view_init(self, azim: float = ..., elev: float = ...) -> None: ...
+    def view_init(
+        self,
+        azim: float = ...,
+        elev: float = ...,
+        center: npt.ArrayLike = ...,
+        distance: float = ...,
+    ) -> None: ...
     def plot(self, P: npt.ArrayLike, c: npt.ArrayLike = ...) -> Line3D: ...
     def scatter(
         self,

--- a/pytransform3d/visualizer/_artists.py
+++ b/pytransform3d/visualizer/_artists.py
@@ -64,7 +64,8 @@ class Line3D(Artist):
         P : array-like, shape (n_points, 3)
             Points of which the line consists.
 
-        c : array-like, shape (n_points - 1, 3) or (3,), optional (default: black)
+        c : array-like, shape (n_points - 1, 3) or (3,), optional
+                (default: black)
             Color can be given as individual colors per line segment or
             as one color for each segment. A color is represented by 3
             values between 0 and 1 indicate representing red, green, and

--- a/pytransform3d/visualizer/_figure.py
+++ b/pytransform3d/visualizer/_figure.py
@@ -224,7 +224,8 @@ class Figure:
         P : array-like, shape (n_points, 3)
             Points of which the line consists.
 
-        c : array-like, shape (n_points - 1, 3) or (3,), optional (default: black)
+        c : array-like, shape (n_points - 1, 3) or (3,), optional
+                (default: black)
             Color can be given as individual colors per line segment or
             as one color for each segment. A color is represented by 3
             values between 0 and 1 indicate representing red, green, and

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ if __name__ == "__main__":
           extras_require={
               "all": ["pydot", "trimesh", "pycollada", "open3d", "viser"],
               "doc": ["numpydoc", "sphinx", "sphinx-gallery",
-                      "pydata-sphinx-theme", "sphinxcontrib.video"],
+                      "pydata-sphinx-theme", "sphinxcontrib.video",
+                      "viser", "trimesh", "playwright", "imageio"],
               "test": ["pytest", "pytest-cov"]
           }
           )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
           packages=find_packages(),
           install_requires=["numpy", "scipy", "matplotlib", "lxml"],
           extras_require={
-              "all": ["pydot", "trimesh", "pycollada", "open3d"],
+              "all": ["pydot", "trimesh", "pycollada", "open3d", "viser"],
               "doc": ["numpydoc", "sphinx", "sphinx-gallery",
                       "pydata-sphinx-theme", "sphinxcontrib.video"],
               "test": ["pytest", "pytest-cov"]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
           install_requires=["numpy", "scipy", "matplotlib", "lxml"],
           extras_require={
               "all": ["pydot", "trimesh", "pycollada", "open3d", "viser"],
+              # playwright also requires: playwright install chromium
               "doc": ["numpydoc", "sphinx", "sphinx-gallery",
                       "pydata-sphinx-theme", "sphinxcontrib.video",
                       "viser", "trimesh", "playwright", "imageio"],


### PR DESCRIPTION
### `pytransform3d.viser` — web-based visualization backend

A new `pytransform3d.viser` module backed by [viser](https://viser.studio/) that is a drop-in replacement for `pytransform3d.visualizer`. It renders in a browser via WebSocket, so it works in headless environments (remote servers, containers, notebooks) where an OpenGL window is unavailable. Switching backends is a one-line import change; both modules share the same public API.

Differences from the Open3D backend: `show()` is non-blocking and prints a URL instead of opening a window; `save_image()` raises `NotImplementedError`; `set_line_width()` is a no-op. `view_init()` gains `center` and `distance` parameters for controlling the orbit target.

Install with `pip install 'pytransform3d[all]'` or `pip install viser`. `trimesh` is required for shapes without a native viser primitive (cylinders, cones, capsules, ellipsoids, vector arrows) and is included in the `all` extras group.

### New examples

Six new examples in `examples/viser/`:

- `vis_viser_shapes` — all geometric primitives in one static scene
- `vis_viser_robot_arm` — animated 6-DOF robot arm with growing TCP trajectory
- `vis_viser_wrench_dynamics` — rigid-body simulation driven by a body-fixed wrench with rolling position trail
- `vis_viser_camera_orbit` — pinhole camera orbiting a static scene, frustum updated every frame
- `vis_viser_uncertain_transforms` — banana distribution from SE(3) uncertainty propagation: MC paths, mean trajectory, projected hyperellipsoid, and Cartesian position ellipsoid
- `vis_viser_probabilistic_robot_kinematics` — PPOE probabilistic forward kinematics with animated end-effector pose-uncertainty ellipsoid

A new user-guide page covers installation, the API, differences from the Open3D backend, and the animation workflow.