### PR TITLE
Fix NaN in axis_angles_from_matrices for exact pi rotations

### DIFF
--- a/pytransform3d/batch_rotations/_matrix.py
+++ b/pytransform3d/batch_rotations/_matrix.py
@@ -66,9 +66,16 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
     else:
         Rs_diag = Rs_diag[0]
 
-    out[angle_close_to_pi, :3] = np.sqrt(
-        0.5 * (Rs_diag[angle_close_to_pi] + 1.0)
-    ) * np.sign(out[angle_close_to_pi, :3])
+    near_pi_signs = np.sign(out[angle_close_to_pi, :3])
+    # When the rotation angle is exactly pi, the skew-symmetric part
+    # (R - R^T)/2 is zero for rotations about a coordinate axis, so
+    # np.sign returns 0 and the axis gets zeroed out. Default to +1 in
+    # that case; the axis direction is recovered from the diagonal.
+    near_pi_signs[near_pi_signs == 0.0] = 1.0
+    out[angle_close_to_pi, :3] = (
+        np.sqrt(np.maximum(0.5 * (Rs_diag[angle_close_to_pi] + 1.0), 0.0))
+        * near_pi_signs
+    )
     out[angle_not_zero, :3] /= np.linalg.norm(out[angle_not_zero, :3], axis=-1)[
         ..., np.newaxis
     ]

--- a/pytransform3d/batch_rotations/test/test_batch_rotations.py
+++ b/pytransform3d/batch_rotations/test/test_batch_rotations.py
@@ -384,6 +384,57 @@ def test_axis_angles_from_matrices_norot():
     )
 
 
+def test_axis_angles_from_matrices_near_pi():
+    """Exact pi rotations about coordinate axes must not produce NaN.
+
+    When R is a 180-degree rotation about a coordinate axis, the
+    skew-symmetric part (R - R^T)/2 is exactly zero, so np.sign
+    returns 0 for every component.  The near-pi branch must fall back
+    to a positive sign to avoid zeroing out the axis before
+    normalisation.
+
+    Regression test for the bug where sign([0,0,0])=[0,0,0] caused
+    a zero-norm axis, a divide-by-zero in the normalisation step, and
+    a NaN result.
+    """
+    # Exact 180-degree rotations about each coordinate axis.
+    Rx = np.diag([1.0, -1.0, -1.0])  # pi about x
+    Ry = np.diag([-1.0, 1.0, -1.0])  # pi about y
+    Rz = np.diag([-1.0, -1.0, 1.0])  # pi about z
+
+    for R, expected_axis in [
+        (Rx, np.array([1.0, 0.0, 0.0])),
+        (Ry, np.array([0.0, 1.0, 0.0])),
+        (Rz, np.array([0.0, 0.0, 1.0])),
+    ]:
+        # 0-dimensional input
+        a = pbr.axis_angles_from_matrices(R)
+        assert np.isfinite(a).all(), f"NaN/Inf for 0-d pi-rotation: {a}"
+        assert abs(a[3] - np.pi) < 1e-6, f"angle should be pi, got {a[3]}"
+        assert_array_almost_equal(np.abs(a[:3]), expected_axis)
+
+        # batched input: mix of pi and non-pi rotations
+        Rs = np.stack([R, np.eye(3), R])
+        A = pbr.axis_angles_from_matrices(Rs)
+        assert np.isfinite(A).all(), f"NaN/Inf in batched pi-rotation: {A}"
+        for i in [0, 2]:
+            assert abs(A[i, 3] - np.pi) < 1e-6
+            assert_array_almost_equal(np.abs(A[i, :3]), expected_axis)
+
+    # Roundtrip: compact axis-angle -> matrix -> axis-angle
+    for axis in [
+        np.array([1.0, 0.0, 0.0]),
+        np.array([0.0, 1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]:
+        compact_in = axis * np.pi
+        R = pbr.matrices_from_compact_axis_angles(compact_in)
+        a = pbr.axis_angles_from_matrices(R)
+        compact_out = a[:3] * a[3]
+        # compact axis-angle is unique only up to sign of axis*angle
+        assert_array_almost_equal(np.abs(compact_out), np.abs(compact_in))
+
+
 def test_axis_angles_from_quaternions():
     rng = np.random.default_rng(48322)
     n_rotations = 20


### PR DESCRIPTION
When the rotation angle is exactly pi about a coordinate axis (e.g. R = diag(1,-1,-1)), the skew-symmetric part (R-R^T)/2 is identically zero. np.sign(0) = 0, so the near-pi branch zeroed out the axis before normalisation, causing a divide-by-zero and NaN output.

Fix: after computing signs from the skew-symmetric part, replace any zero signs with +1. The axis direction for those components is already determined by sqrt(0.5*(diag+1)), which is 0 for the components that don't contribute, so the sign of zero components is irrelevant.

Also guard the sqrt with np.maximum(..., 0) to avoid sqrt of small negative values from floating-point noise.

Adds test_axis_angles_from_matrices_near_pi covering:
- 0-d and batched exact-pi rotations about all three coordinate axes
- mixed batches (pi and identity)
- compact axis-angle roundtrip at theta=pi