### PR TITLE
Development branch, release 3.16

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -136,6 +136,8 @@ Quaternion
    ~quaternion_slerp
    ~quaternion_dist
    ~quaternion_diff
+   ~swing_twist_decomposition
+   ~swing_twist_composition
    ~quaternion_gradient
    ~quaternion_integrate
    ~quaternion_from_angle

--- a/doc/source/user_guide/introduction.rst
+++ b/doc/source/user_guide/introduction.rst
@@ -123,9 +123,8 @@ References
 
 .. [2] Furgale, P. (2014). Representing Robot Pose: The good, the bad, and the
    ugly (slides). In What Sucks in Robotics and How to Fix It: Lessons Learned
-   from Building Complex Systems (ICRA workshop). Note: these slides seem to be
-   lost, but the blog below conveys the same message.
-   http://static.squarespace.com/static/523c5c56e4b0abc2df5e163e/t/53957839e4b05045ad65021d/1402304569659/Workshop+-+Rotations_v102.key.pdf
+   from Building Complex Systems (ICRA workshop).
+   https://web.archive.org/web/20150318020847/http://static1.squarespace.com/static/523c5c56e4b0abc2df5e163e/t/53957839e4b05045ad65021d/1402304569659/Workshop+-+Rotations_v102.key.pdf
 
 .. [3] Furgale, P. (2014). Representing Robot Pose: The good, the bad, and the
    ugly (blog).

--- a/doc/source/user_guide/rotations.rst
+++ b/doc/source/user_guide/rotations.rst
@@ -398,6 +398,59 @@ with the quaternion product (:func:`~pytransform3d.rotations.q_prod_vector`).
 * Interpretation: not straightforward.
 * Ambiguities: double cover.
 
+Swing-Twist Decomposition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any rotation can be split into a *twist* about a chosen axis
+:math:`\boldsymbol{e}` and a *swing* that carries the remaining orientation,
+such that
+
+.. math::
+
+    \boldsymbol{q} = \boldsymbol{q}_{swing} \boldsymbol{q}_{twist},
+
+where the twist is applied first. The twist
+:math:`\boldsymbol{q}_{twist}` is a rotation about :math:`\boldsymbol{e}`
+and the swing :math:`\boldsymbol{q}_{swing}` is a rotation about an axis that
+is orthogonal to :math:`\boldsymbol{e}` [9]_. The twist is obtained by
+projecting the vector part of the quaternion onto the twist axis and
+renormalizing; the swing is then recovered as
+:math:`\boldsymbol{q}_{swing} = \boldsymbol{q} \boldsymbol{q}_{twist}^{-1}`.
+
+This is useful to separate the roll about a link axis from the rest of an
+orientation, to enforce joint limits, or to isolate the rotation about a
+symmetry axis. pytransform3d provides
+:func:`~pytransform3d.rotations.swing_twist_decomposition` and the inverse
+:func:`~pytransform3d.rotations.swing_twist_composition`, which reconstructs
+the original rotation from swing and twist.
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    from pytransform3d.rotations import (
+        swing_twist_decomposition, quaternion_from_axis_angle,
+        matrix_from_quaternion, plot_basis)
+
+    axis = np.array([0.0, 0.0, 1.0])
+    q = quaternion_from_axis_angle([0.3, 0.7, 0.2, 1.2])
+    swing, twist = swing_twist_decomposition(q, axis)
+
+    ax = plot_basis(R=matrix_from_quaternion(q), p=[0, 0, 0])
+    plot_basis(ax=ax, R=matrix_from_quaternion(twist), p=[3, 0, 0])
+    plot_basis(ax=ax, R=matrix_from_quaternion(swing), p=[6, 0, 0])
+
+The left frame shows the full rotation, the middle frame the twist (a pure
+rotation about the z-axis), and the right frame the swing.
+
+.. warning::
+
+    The twist is undefined for a rotation by :math:`\pi` about an axis
+    orthogonal to the twist axis: both the scalar part and the projection onto
+    the twist axis vanish. In this degenerate case
+    :func:`~pytransform3d.rotations.swing_twist_decomposition` returns the
+    identity as the twist and lets the swing carry the full rotation.
+
 ------------
 Euler Angles
 ------------
@@ -565,3 +618,5 @@ References
 .. [8] Shuster, M. D. (1993). A Survey of Attitude Representations.
    Journal of the Astronautical Sciences, 41, 439-517.
    http://malcolmdshuster.com/Pub_1993h_J_Repsurv_scan.pdf
+.. [9] Dobrowolski, P. (2015). Swing-twist decomposition in Clifford algebra.
+   https://arxiv.org/abs/1506.05481

--- a/doc/source/user_guide/rotations.rst
+++ b/doc/source/user_guide/rotations.rst
@@ -399,7 +399,7 @@ with the quaternion product (:func:`~pytransform3d.rotations.q_prod_vector`).
 * Ambiguities: double cover.
 
 Swing-Twist Decomposition
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Any rotation can be split into a *twist* about a chosen axis
 :math:`\boldsymbol{e}` and a *swing* that carries the remaining orientation,
@@ -407,15 +407,15 @@ such that
 
 .. math::
 
-    \boldsymbol{q} = \boldsymbol{q}_{swing} \boldsymbol{q}_{twist},
+    \boldsymbol{q} = \boldsymbol{q}_\text{swing} \boldsymbol{q}_\text{twist},
 
 where the twist is applied first. The twist
-:math:`\boldsymbol{q}_{twist}` is a rotation about :math:`\boldsymbol{e}`
-and the swing :math:`\boldsymbol{q}_{swing}` is a rotation about an axis that
+:math:`\boldsymbol{q}_\text{twist}` is a rotation about :math:`\boldsymbol{e}`
+and the swing :math:`\boldsymbol{q}_\text{swing}` is a rotation about an axis that
 is orthogonal to :math:`\boldsymbol{e}` [9]_. The twist is obtained by
 projecting the vector part of the quaternion onto the twist axis and
 renormalizing; the swing is then recovered as
-:math:`\boldsymbol{q}_{swing} = \boldsymbol{q} \boldsymbol{q}_{twist}^{-1}`.
+:math:`\boldsymbol{q}_\text{swing} = \boldsymbol{q} \boldsymbol{q}_\text{twist}^{-1}`.
 
 This is useful to separate the roll about a link axis from the rest of an
 orientation, to enforce joint limits, or to isolate the rotation about a
@@ -429,8 +429,11 @@ the original rotation from swing and twist.
 
     import numpy as np
     from pytransform3d.rotations import (
-        swing_twist_decomposition, quaternion_from_axis_angle,
-        matrix_from_quaternion, plot_basis)
+        swing_twist_decomposition,
+        quaternion_from_axis_angle,
+        matrix_from_quaternion,
+        plot_basis,
+    )
 
     axis = np.array([0.0, 0.0, 1.0])
     q = quaternion_from_axis_angle([0.3, 0.7, 0.2, 1.2])

--- a/examples/plots/plot_swing_twist.py
+++ b/examples/plots/plot_swing_twist.py
@@ -1,0 +1,78 @@
+"""
+==========================
+Swing-Twist Decomposition
+==========================
+
+Any rotation can be split into a *twist* about a chosen axis and a *swing*
+that rotates the axis itself, such that ``q = swing * twist`` (the twist is
+applied first). The twist is a rotation about the given axis and the swing is a
+rotation about an axis orthogonal to it. This is convenient, for example, to
+separate the roll about a link axis from the remaining orientation.
+
+Here the twist axis is the body z-axis. We take an arbitrary rotation,
+decompose it into its swing and twist components, and recompose them to recover
+the original orientation.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pytransform3d.rotations import (
+    axis_angle_from_quaternion,
+    matrix_from_quaternion,
+    plot_axis_angle,
+    plot_basis,
+    quaternion_from_axis_angle,
+    swing_twist_composition,
+    swing_twist_decomposition,
+)
+
+# %%
+# We pick an arbitrary rotation and decompose it about the body z-axis. The
+# decomposition returns a swing (a rotation about an axis orthogonal to z) and
+# a twist (a rotation about z).
+axis = np.array([0.0, 0.0, 1.0])
+q = quaternion_from_axis_angle([0.6, 0.3, 0.8, np.deg2rad(100.0)])
+
+swing, twist = swing_twist_decomposition(q, axis)
+
+# %%
+# Recomposing the swing and twist recovers the original rotation. The
+# reconstruction may differ in sign, since a quaternion and its negation
+# represent the same rotation, so we compare rotation matrices.
+q_recomposed = swing_twist_composition(swing, twist)
+print(
+    "Recomposition matches original:",
+    np.allclose(
+        matrix_from_quaternion(q), matrix_from_quaternion(q_recomposed)
+    ),
+)
+
+# %%
+# We visualize the pieces as a sequence of frames along the x-axis. From left
+# to right: the original rotation, the isolated swing, the isolated twist, and
+# the recomposed rotation (swing * twist), which coincides with the original.
+# The black arrow marks the twist axis and its arc shows the twist angle.
+frames = [
+    (q, "original", 0.0),
+    (swing, "swing", 2.5),
+    (twist, "twist", 5.0),
+    (q_recomposed, "swing * twist", 7.5),
+]
+
+ax = None
+for q_i, label, offset in frames:
+    p = np.array([offset, 0.0, 0.0])
+    ax = plot_basis(ax=ax, R=matrix_from_quaternion(q_i), p=p, ax_s=4, lw=3)
+    ax.text(offset, 0.0, -2.0, label, ha="center")
+
+# Draw the twist axis and angle on the twist frame.
+plot_axis_angle(ax, axis_angle_from_quaternion(twist), p=[5.0, 0.0, 0.0])
+
+ax.view_init(elev=25, azim=-60)
+ax.set_xlim((-1.5, 9.0))
+ax.set_ylim((-3.0, 3.0))
+ax.set_zlim((-3.0, 3.0))
+ax.set_box_aspect((10.5, 6.0, 6.0))
+plt.subplots_adjust(left=0, right=1, bottom=0, top=1)
+plt.show()

--- a/examples/plots/plot_swing_twist.py
+++ b/examples/plots/plot_swing_twist.py
@@ -1,7 +1,7 @@
 """
-==========================
+=========================
 Swing-Twist Decomposition
-==========================
+=========================
 
 Any rotation can be split into a *twist* about a chosen axis and a *swing*
 that rotates the axis itself, such that ``q = swing * twist`` (the twist is

--- a/examples/plots/plot_swing_twist_tool_axis.py
+++ b/examples/plots/plot_swing_twist_tool_axis.py
@@ -1,0 +1,116 @@
+"""
+=========================================
+Tool-Axis Redundancy via Swing and Twist
+=========================================
+
+Many robot tasks only constrain the *direction* a tool points, not the roll
+about the tool's own axis. Drilling, deburring, spraying, or spot welding all
+leave the rotation about the tool axis free, because the tool is symmetric
+about it. Swing-twist decomposition isolates exactly this redundant degree of
+freedom.
+
+Choosing the tool axis as the twist axis, an end-effector orientation splits
+into a *swing* that aims the tool axis (the task-relevant approach direction)
+and a *twist* that rolls the tool about that axis (the redundant part). We take
+a nominal end-effector orientation, recover its swing and twist, and then sweep
+the twist to generate a whole family of orientations that all keep the tool
+pointing the same way.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pytransform3d.rotations import (
+    axis_angle_from_two_directions,
+    matrix_from_quaternion,
+    plot_basis,
+    quaternion_from_axis_angle,
+    swing_twist_composition,
+    swing_twist_decomposition,
+    unitz,
+)
+
+# %%
+# The tool axis is the end-effector's body z-axis. We build a nominal
+# orientation that aims the tool along a desired approach direction and adds
+# some arbitrary roll, then decompose it about the tool axis. The swing
+# encodes where the tool axis points; the twist is the roll about it.
+tool_axis = unitz
+approach = np.array([1.0, -0.7, -0.6])
+approach = approach / np.linalg.norm(approach)
+
+aim = quaternion_from_axis_angle(
+    axis_angle_from_two_directions(unitz, approach)
+)
+roll = quaternion_from_axis_angle(np.hstack((tool_axis, np.deg2rad(40.0))))
+q_nominal = swing_twist_composition(aim, roll)
+
+swing, twist = swing_twist_decomposition(q_nominal, tool_axis)
+
+# %%
+# Sweeping the twist while holding the swing fixed produces end-effector
+# orientations that all share the same tool-axis direction -- only the roll
+# about the tool changes. This is the family of solutions a task-space planner
+# is free to pick from, e.g. to dodge a joint limit or an obstacle.
+twist_angles = np.linspace(0.0, 2.0 * np.pi, 12, endpoint=False)
+family = [
+    swing_twist_composition(
+        swing, quaternion_from_axis_angle(np.hstack((tool_axis, angle)))
+    )
+    for angle in twist_angles
+]
+
+# The tool tip sits at a workpiece; the end-effector is set back along the
+# approach direction so the tool axis points at the workpiece.
+workpiece = np.zeros(3)
+reach = 1.4
+tcp = workpiece - reach * approach
+
+# %%
+# The nominal end-effector orientation is drawn as a full frame, with its blue
+# tool axis running down the dashed shaft to the workpiece. The rest of the
+# family is shown as a pinwheel: each spoke is a reference mark painted on the
+# tool (its x-axis) at one twist angle, colored from dark to bright as the roll
+# advances. Every spoke shares the same tool axis; only the roll differs.
+radius = 0.5
+ax = plot_basis(
+    R=matrix_from_quaternion(q_nominal), p=tcp, s=radius, ax_s=1.5, lw=4
+)
+
+# Tool shaft from the end-effector to the workpiece and the workpiece itself.
+ax.plot(*np.column_stack((tcp, workpiece)), "--", color="k", lw=2)
+ax.scatter(*workpiece, color="k", s=60)
+ax.text(*(workpiece + [0.05, 0.05, 0.1]), "workpiece")
+
+# Circle traced by the tool's x-axis to emphasize the free roll.
+fine = np.linspace(0.0, 2.0 * np.pi, 60)
+ring = np.array(
+    [
+        tcp
+        + radius
+        * matrix_from_quaternion(
+            swing_twist_composition(
+                swing, quaternion_from_axis_angle(np.hstack((tool_axis, a)))
+            )
+        )[:, 0]
+        for a in fine
+    ]
+)
+ax.plot(ring[:, 0], ring[:, 1], ring[:, 2], color="gray", lw=1)
+
+# Pinwheel spokes: the tool's x-axis reference mark at each twist angle.
+colors = plt.cm.viridis(np.linspace(0.0, 1.0, len(family), endpoint=False))
+for q, color in zip(family, colors):
+    tip = tcp + radius * matrix_from_quaternion(q)[:, 0]
+    ax.plot(*np.column_stack((tcp, tip)), color=color, lw=2)
+    ax.scatter(*tip, color=color, s=25)
+
+ax.view_init(elev=28, azim=-55)
+lo = np.minimum(tcp, workpiece) - 0.6
+hi = np.maximum(tcp, workpiece) + 0.6
+ax.set_xlim((lo[0], hi[0]))
+ax.set_ylim((lo[1], hi[1]))
+ax.set_zlim((lo[2], hi[2]))
+ax.set_box_aspect(hi - lo)
+plt.subplots_adjust(left=0, right=1, bottom=0, top=1)
+plt.show()

--- a/examples/plots/plot_swing_twist_tool_axis.py
+++ b/examples/plots/plot_swing_twist_tool_axis.py
@@ -1,7 +1,7 @@
 """
-=========================================
+========================================
 Tool-Axis Redundancy via Swing and Twist
-=========================================
+========================================
 
 Many robot tasks only constrain the *direction* a tool points, not the roll
 about the tool's own axis. Drilling, deburring, spraying, or spot welding all

--- a/pytransform3d/__init__.py
+++ b/pytransform3d/__init__.py
@@ -1,3 +1,3 @@
 """3D transformations for Python."""
 
-__version__ = "3.15.0"
+__version__ = "3.16.0"

--- a/pytransform3d/_mesh_loader.py
+++ b/pytransform3d/_mesh_loader.py
@@ -110,7 +110,7 @@ class _Trimesh(MeshBase):
             else:
                 raise e
         self.mesh = trimesh.load_mesh(self.filename)
-        if isinstance(self.mesh, trimesh.Scene):
+        if isinstance(self.mesh, trimesh.Scene):  # pragma: no cover
             open3d_mesh = self._scene_to_open3d_mesh(self.mesh)
             self.mesh = self._open3d_mesh_to_trimesh(open3d_mesh)
         return True

--- a/pytransform3d/batch_rotations/_axis_angle.py
+++ b/pytransform3d/batch_rotations/_axis_angle.py
@@ -18,7 +18,7 @@ def norm_axis_angles(a):
     -------
     a : array, shape (..., 4)
         Axis of rotation and rotation angle: (x, y, z, angle). The length
-        of the axis vector is 1 and the angle is in [0, pi). No rotation
+        of the axis vector is 1 and the angle is in [0, pi]. No rotation
         is represented by [1, 0, 0, 0].
     """
     a = np.asarray(a)

--- a/pytransform3d/batch_rotations/_matrix.py
+++ b/pytransform3d/batch_rotations/_matrix.py
@@ -50,32 +50,35 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
 
     # The threshold is a result from this discussion:
     # https://github.com/dfki-ric/pytransform3d/issues/43
-    # The standard formula becomes numerically unstable, however,
-    # Rodrigues' formula reduces to R = I + 2 (ee^T - I), with the
-    # rotation axis e, that is, ee^T = 0.5 * (R + I) and we can find the
-    # squared values of the rotation axis on the diagonal of this matrix.
-    # We can still use the original formula to reconstruct the signs of
-    # the rotation axis correctly.
+    # The standard formula becomes numerically unstable near pi.
     angle_close_to_pi = np.abs(angles - np.pi) < 1e-4
     angle_zero = angles == 0.0
     angle_not_zero = np.logical_not(angle_zero)
 
-    Rs_diag = np.einsum("nii->ni", Rs.reshape(-1, 3, 3))
-    if instances_shape:
-        Rs_diag = Rs_diag.reshape(*(instances_shape + (3,)))
-    else:
-        Rs_diag = Rs_diag[0]
+    if np.any(angle_close_to_pi):
+        # ee^T = 0.5 * (R + I) has the squared axis components on its
+        # diagonal. At exactly pi the skew part R - R^T (out[..., :3]) is
+        # numerically zero, so its sign cannot recover the axis for a general
+        # (non-coordinate) axis. We take the relative signs from the dominant
+        # row of ee^T instead, using the symmetric part of R to stay accurate
+        # just below pi, where the skew part then fixes the overall axis sign.
+        Rs_pi = Rs[angle_close_to_pi]
+        Rs_pi_sym = 0.5 * (Rs_pi + np.swapaxes(Rs_pi, -1, -2))
+        eeT_diag = np.clip(
+            0.5 * (np.diagonal(Rs_pi_sym, axis1=-2, axis2=-1) + 1.0), 0.0, 1.0
+        )
+        rows = np.arange(len(eeT_diag))
+        k = np.argmax(eeT_diag, axis=-1)  # dominant component per instance
+        signs = np.sign(Rs_pi_sym[rows, k])
+        signs[rows, k] = 1.0
+        axes = np.sqrt(eeT_diag) * signs
+        # just below pi the skew part gives the overall sign of the axis
+        skew = out[angle_close_to_pi, :3]
+        determined = angles[angle_close_to_pi] < np.pi
+        flip = determined & (np.sum(axes * skew, axis=-1) < 0.0)
+        axes[flip] = -axes[flip]
+        out[angle_close_to_pi, :3] = axes
 
-    near_pi_signs = np.sign(out[angle_close_to_pi, :3])
-    # When the rotation angle is exactly pi, the skew-symmetric part
-    # (R - R^T)/2 is zero for rotations about a coordinate axis, so
-    # np.sign returns 0 and the axis gets zeroed out. Default to +1 in
-    # that case; the axis direction is recovered from the diagonal.
-    near_pi_signs[near_pi_signs == 0.0] = 1.0
-    out[angle_close_to_pi, :3] = (
-        np.sqrt(np.maximum(0.5 * (Rs_diag[angle_close_to_pi] + 1.0), 0.0))
-        * near_pi_signs
-    )
     out[angle_not_zero, :3] /= np.linalg.norm(out[angle_not_zero, :3], axis=-1)[
         ..., np.newaxis
     ]

--- a/pytransform3d/batch_rotations/_matrix.py
+++ b/pytransform3d/batch_rotations/_matrix.py
@@ -13,7 +13,7 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
     Rs : array-like, shape (..., 3, 3)
         Rotation matrices
 
-    traces : array, shape (..., 3)
+    traces : array, shape (...)
         If the traces of rotation matrices been precomputed, you can pass them
         here.
 

--- a/pytransform3d/batch_rotations/_matrix.py
+++ b/pytransform3d/batch_rotations/_matrix.py
@@ -66,9 +66,16 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
     else:
         Rs_diag = Rs_diag[0]
 
-    out[angle_close_to_pi, :3] = np.sqrt(
-        0.5 * (Rs_diag[angle_close_to_pi] + 1.0)
-    ) * np.sign(out[angle_close_to_pi, :3])
+    near_pi_signs = np.sign(out[angle_close_to_pi, :3])
+    # When the rotation angle is exactly pi, the skew-symmetric part
+    # (R - R^T)/2 is zero for rotations about a coordinate axis, so
+    # np.sign returns 0 and the axis gets zeroed out. Default to +1 in
+    # that case; the axis direction is recovered from the diagonal.
+    near_pi_signs[near_pi_signs == 0.0] = 1.0
+    out[angle_close_to_pi, :3] = (
+        np.sqrt(np.maximum(0.5 * (Rs_diag[angle_close_to_pi] + 1.0), 0.0))
+        * near_pi_signs
+    )
     out[angle_not_zero, :3] /= np.linalg.norm(out[angle_not_zero, :3], axis=-1)[
         ..., np.newaxis
     ]

--- a/pytransform3d/batch_rotations/_matrix.py
+++ b/pytransform3d/batch_rotations/_matrix.py
@@ -48,20 +48,24 @@ def axis_angles_from_matrices(Rs, traces=None, out=None):
     out[..., 1] = Rs[..., 0, 2] - Rs[..., 2, 0]
     out[..., 2] = Rs[..., 1, 0] - Rs[..., 0, 1]
 
-    # The threshold is a result from this discussion:
-    # https://github.com/dfki-ric/pytransform3d/issues/43
-    # The standard formula becomes numerically unstable near pi.
     angle_close_to_pi = np.abs(angles - np.pi) < 1e-4
     angle_zero = angles == 0.0
     angle_not_zero = np.logical_not(angle_zero)
 
     if np.any(angle_close_to_pi):
-        # ee^T = 0.5 * (R + I) has the squared axis components on its
-        # diagonal. At exactly pi the skew part R - R^T (out[..., :3]) is
-        # numerically zero, so its sign cannot recover the axis for a general
-        # (non-coordinate) axis. We take the relative signs from the dominant
-        # row of ee^T instead, using the symmetric part of R to stay accurate
-        # just below pi, where the skew part then fixes the overall axis sign.
+        # Near pi the standard formula is numerically unstable. The 1e-4
+        # threshold comes from
+        # https://github.com/dfki-ric/pytransform3d/issues/43.
+        #
+        # At pi, R is symmetric, so the skew part R - R^T is zero and its
+        # sign cannot recover a general axis. From Rodrigues' formula
+        # R = 2 ee^T - I at pi, i.e. ee^T = 0.5 * (R + I), whose diagonal
+        # holds the squared axis components e_i^2. We read the magnitudes
+        # |e_i| off that diagonal and the relative signs off the dominant
+        # row k = argmax(e_i^2) of the symmetric part, where
+        # R_sym[k, j] gives sign(e_k) * sign(e_j). Using the symmetric part
+        # (not R) keeps this accurate just below pi, where the skew part then
+        # fixes the overall sign of the axis.
         Rs_pi = Rs[angle_close_to_pi]
         Rs_pi_sym = 0.5 * (Rs_pi + np.swapaxes(Rs_pi, -1, -2))
         eeT_diag = np.clip(

--- a/pytransform3d/batch_rotations/test/test_batch_rotations.py
+++ b/pytransform3d/batch_rotations/test/test_batch_rotations.py
@@ -435,6 +435,28 @@ def test_axis_angles_from_matrices_near_pi():
         assert_array_almost_equal(np.abs(compact_out), np.abs(compact_in))
 
 
+def test_axis_angles_from_matrices_pi_general_axis():
+    """Recover general (non-coordinate) axes for pi rotations in a batch.
+
+    test_axis_angles_from_matrices_near_pi only covers coordinate axes (#364),
+    for which the off-diagonal axis components are zero. For a general axis the
+    signs matter and must be taken from the symmetric part of the matrix.
+    """
+    rng = np.random.default_rng(84)
+    axes = pbr.norm_vectors(rng.standard_normal((20, 3)))
+    for angle in [np.pi, np.pi - 1e-6, np.pi - 1e-9]:
+        A = axes * angle
+        Rs = pbr.matrices_from_compact_axis_angles(A)
+        A2 = pbr.axis_angles_from_matrices(Rs)
+        Rs2 = pbr.matrices_from_compact_axis_angles(A2[..., :3] * A2[..., 3:])
+        assert_array_almost_equal(Rs2, Rs)
+        # the batch result agrees with the single-matrix implementation
+        for R in Rs:
+            assert_array_almost_equal(
+                pbr.axis_angles_from_matrices(R), pr.axis_angle_from_matrix(R)
+            )
+
+
 def test_axis_angles_from_quaternions():
     rng = np.random.default_rng(48322)
     n_rotations = 20

--- a/pytransform3d/batch_rotations/test/test_batch_rotations.py
+++ b/pytransform3d/batch_rotations/test/test_batch_rotations.py
@@ -384,6 +384,57 @@ def test_axis_angles_from_matrices_norot():
     )
 
 
+def test_axis_angles_from_matrices_near_pi():
+    """Exact pi rotations about coordinate axes must not produce NaN.
+
+    When R is a 180-degree rotation about a coordinate axis, the
+    skew-symmetric part (R - R^T)/2 is exactly zero, so np.sign
+    returns 0 for every component.  The near-pi branch must fall back
+    to a positive sign to avoid zeroing out the axis before
+    normalisation.
+
+    Regression test for the bug where sign([0,0,0])=[0,0,0] caused
+    a zero-norm axis, a divide-by-zero in the normalisation step, and
+    a NaN result.
+    """
+    # Exact 180-degree rotations about each coordinate axis.
+    Rx = np.diag([1.0, -1.0, -1.0])  # pi about x
+    Ry = np.diag([-1.0, 1.0, -1.0])  # pi about y
+    Rz = np.diag([-1.0, -1.0, 1.0])  # pi about z
+
+    for R, expected_axis in [
+        (Rx, np.array([1.0, 0.0, 0.0])),
+        (Ry, np.array([0.0, 1.0, 0.0])),
+        (Rz, np.array([0.0, 0.0, 1.0])),
+    ]:
+        # 0-dimensional input
+        a = pbr.axis_angles_from_matrices(R)
+        assert np.isfinite(a).all(), f"NaN/Inf for 0-d pi-rotation: {a}"
+        assert abs(a[3] - np.pi) < 1e-6, f"angle should be pi, got {a[3]}"
+        assert_array_almost_equal(np.abs(a[:3]), expected_axis)
+
+        # batched input: mix of pi and non-pi rotations
+        Rs = np.stack([R, np.eye(3), R])
+        A = pbr.axis_angles_from_matrices(Rs)
+        assert np.isfinite(A).all(), f"NaN/Inf in batched pi-rotation: {A}"
+        for i in [0, 2]:
+            assert abs(A[i, 3] - np.pi) < 1e-6
+            assert_array_almost_equal(np.abs(A[i, :3]), expected_axis)
+
+    # Roundtrip: compact axis-angle -> matrix -> axis-angle
+    for axis in [
+        np.array([1.0, 0.0, 0.0]),
+        np.array([0.0, 1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]:
+        compact_in = axis * np.pi
+        R = pbr.matrices_from_compact_axis_angles(compact_in)
+        a = pbr.axis_angles_from_matrices(R)
+        compact_out = a[:3] * a[3]
+        # compact axis-angle is unique only up to sign of axis*angle
+        assert_array_almost_equal(np.abs(compact_out), np.abs(compact_in))
+
+
 def test_axis_angles_from_quaternions():
     rng = np.random.default_rng(48322)
     n_rotations = 20

--- a/pytransform3d/rotations/__init__.py
+++ b/pytransform3d/rotations/__init__.py
@@ -138,6 +138,7 @@ from ._jacobians import (
     left_jacobian_SO3_inv_series,
 )
 from ._polar_decomp import robust_polar_decomposition
+from ._swing_twist import swing_twist_decomposition, swing_twist_composition
 from ._plot import (
     plot_basis,
     plot_axis_angle,
@@ -361,4 +362,6 @@ __all__ = [
     "left_jacobian_SO3_inv",
     "left_jacobian_SO3_inv_series",
     "robust_polar_decomposition",
+    "swing_twist_decomposition",
+    "swing_twist_composition",
 ]

--- a/pytransform3d/rotations/_jacobians.py
+++ b/pytransform3d/rotations/_jacobians.py
@@ -40,7 +40,16 @@ def left_jacobian_SO3(omega):
     """
     omega = np.asarray(omega)
     theta = np.linalg.norm(omega)
-    if theta < np.finfo(float).eps:
+    # The closed-form terms (1 - cos(t))/t and 1 - sin(t)/t involve
+    # subtracting a value near 1 from 1.  The leading correction is O(t)
+    # and O(t^2) respectively.  When that correction is smaller than half
+    # a ULP (unit in the last place, i.e. the spacing between adjacent
+    # floats) of 1.0, the subtraction result is exactly 0 and all
+    # significant bits are lost.  ULP(1.0) = eps = 2^-52 ~= 2.2e-16 for
+    # float64.  The tighter condition, 1 - sin(t)/t ~= t^2/6 < eps/2,
+    # gives t < sqrt(3*eps).  We use sqrt(6*eps) (~3.65e-8) as a
+    # slightly conservative threshold that also covers the inverse.
+    if theta < math.sqrt(6.0 * np.finfo(float).eps):
         return left_jacobian_SO3_series(omega, 10)
     omega_unit = omega / theta
     omega_matrix = cross_product_matrix(omega_unit)
@@ -112,7 +121,10 @@ def left_jacobian_SO3_inv(omega):
     """
     omega = np.asarray(omega)
     theta = np.linalg.norm(omega)
-    if theta < np.finfo(float).eps:
+    # 1 - t/(2*tan(t/2)) ~= t^2/12 for small t.  This falls below half a
+    # ULP (unit in the last place) of 1.0 for t < sqrt(6*eps), so the
+    # subtraction yields exactly 0 in float64.  Use the series instead.
+    if theta < math.sqrt(6.0 * np.finfo(float).eps):
         return left_jacobian_SO3_inv_series(omega, 10)
     omega_unit = omega / theta
     omega_matrix = cross_product_matrix(omega_unit)

--- a/pytransform3d/rotations/_matrix.py
+++ b/pytransform3d/rotations/_matrix.py
@@ -348,18 +348,22 @@ def axis_angle_from_matrix(R, strict_check=True, check=True):
         # https://github.com/dfki-ric/pytransform3d/issues/43
         # The standard formula becomes numerically unstable, however,
         # Rodrigues' formula reduces to R = I + 2 (ee^T - I), with the
-        # rotation axis e, that is, ee^T = 0.5 * (R + I) and we can find the
-        # squared values of the rotation axis on the diagonal of this matrix.
-        # We can still use the original formula to reconstruct the signs of
-        # the rotation axis correctly.
-
-        # In case of floating point inaccuracies:
-        R_diag = np.clip(np.diag(R), -1.0, 1.0)
-
-        eeT_diag = 0.5 * (R_diag + 1.0)
-        signs = np.sign(axis_unnormalized)
-        signs[signs == 0.0] = 1.0
+        # rotation axis e, that is, ee^T = 0.5 * (R + I), whose diagonal
+        # holds the squared axis components. At exactly pi the skew part
+        # R - R^T is numerically zero, so its sign cannot recover the axis
+        # for a general axis (only a coordinate axis, whose off-diagonal
+        # components are zero, was handled before). We take the relative
+        # signs from the dominant row of ee^T instead. The symmetric part
+        # keeps this accurate just below pi, where the skew part then fixes
+        # the overall sign of the axis.
+        R_sym = 0.5 * (R + R.T)
+        eeT_diag = np.clip(0.5 * (np.diag(R_sym) + 1.0), 0.0, 1.0)
+        k = np.argmax(eeT_diag)
+        signs = np.sign(R_sym[k])
+        signs[k] = 1.0
         a[:3] = np.sqrt(eeT_diag) * signs
+        if angle < np.pi and np.dot(a[:3], axis_unnormalized) < 0.0:
+            a[:3] = -a[:3]
     else:
         a[:3] = axis_unnormalized
         # The norm of axis_unnormalized is 2.0 * np.sin(angle), that is, we

--- a/pytransform3d/rotations/_matrix.py
+++ b/pytransform3d/rotations/_matrix.py
@@ -344,18 +344,19 @@ def axis_angle_from_matrix(R, strict_check=True, check=True):
     )
 
     if abs(angle - np.pi) < 1e-4:  # np.trace(R) close to -1
-        # The threshold 1e-4 is a result from this discussion:
-        # https://github.com/dfki-ric/pytransform3d/issues/43
-        # The standard formula becomes numerically unstable, however,
-        # Rodrigues' formula reduces to R = I + 2 (ee^T - I), with the
-        # rotation axis e, that is, ee^T = 0.5 * (R + I), whose diagonal
-        # holds the squared axis components. At exactly pi the skew part
-        # R - R^T is numerically zero, so its sign cannot recover the axis
-        # for a general axis (only a coordinate axis, whose off-diagonal
-        # components are zero, was handled before). We take the relative
-        # signs from the dominant row of ee^T instead. The symmetric part
-        # keeps this accurate just below pi, where the skew part then fixes
-        # the overall sign of the axis.
+        # Near pi the standard formula is numerically unstable. The 1e-4
+        # threshold comes from
+        # https://github.com/dfki-ric/pytransform3d/issues/43.
+        #
+        # At pi, R is symmetric, so the skew part R - R^T is zero and its
+        # sign cannot recover a general axis. From Rodrigues' formula
+        # R = 2 ee^T - I at pi, i.e. ee^T = 0.5 * (R + I), whose diagonal
+        # holds the squared axis components e_i^2. We read the magnitudes
+        # |e_i| off that diagonal and the relative signs off the dominant
+        # row k = argmax(e_i^2) of the symmetric part, where
+        # R_sym[k, j] gives sign(e_k) * sign(e_j). Using the symmetric part
+        # (not R) keeps this accurate just below pi, where the skew part then
+        # fixes the overall sign of the axis.
         R_sym = 0.5 * (R + R.T)
         eeT_diag = np.clip(0.5 * (np.diag(R_sym) + 1.0), 0.0, 1.0)
         k = np.argmax(eeT_diag)

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -227,9 +227,11 @@ def slerp_weights(angle, t):
     w2 : float or array, shape (n_steps,)
         Weights for quaternion 2
     """
-    if angle == 0.0:
-        return np.ones_like(t), np.zeros_like(t)
+    sin_angle = np.sin(angle)
+    if abs(sin_angle) < np.finfo(float).eps:
+        # angle ~= 0 or angle ~= pi (antipodal): fall back to linear blend
+        return (1.0 - t) * np.ones_like(t), t * np.ones_like(t)
     return (
-        np.sin((1.0 - t) * angle) / np.sin(angle),
-        np.sin(t * angle) / np.sin(angle),
+        np.sin((1.0 - t) * angle) / sin_angle,
+        np.sin(t * angle) / sin_angle,
     )

--- a/pytransform3d/rotations/_swing_twist.py
+++ b/pytransform3d/rotations/_swing_twist.py
@@ -1,0 +1,152 @@
+"""Swing-twist decomposition of a rotation."""
+
+import numpy as np
+
+from ._quaternion import check_quaternion, concatenate_quaternions, q_conj
+from ._utils import norm_vector
+
+
+def swing_twist_decomposition(q, axis, eps=np.finfo(float).eps):
+    r"""Decompose quaternion into swing and twist about an axis.
+
+    Any rotation :math:`\boldsymbol{q}` can be split into a *twist* about a
+    given axis :math:`\boldsymbol{e}` and a *swing* that rotates the axis
+    itself, such that
+
+    .. math::
+
+        \boldsymbol{q} = \boldsymbol{q}_{swing} \boldsymbol{q}_{twist},
+
+    where the twist is applied first. The twist
+    :math:`\boldsymbol{q}_{twist}` is a rotation about :math:`\boldsymbol{e}`
+    and the swing :math:`\boldsymbol{q}_{swing}` is a rotation about an axis
+    that is orthogonal to :math:`\boldsymbol{e}` [1]_.
+
+    The twist is obtained by projecting the vector part of the quaternion
+    onto the twist axis and renormalizing; the swing is then recovered as
+    :math:`\boldsymbol{q}_{swing} = \boldsymbol{q}
+    \boldsymbol{q}_{twist}^{-1}`.
+
+    This decomposition is useful, for example, to enforce joint limits, to
+    separate the roll about a link axis from the remaining orientation, or to
+    isolate the rotation about a symmetry axis.
+
+    Parameters
+    ----------
+    q : array-like, shape (4,)
+        Unit quaternion to represent rotation: (w, x, y, z).
+
+    axis : array-like, shape (3,)
+        Twist axis. Does not have to be normalized.
+
+    eps : float, optional (default: np.finfo(float).eps)
+        Threshold for degeneracy detection
+
+
+    Returns
+    -------
+    swing : array, shape (4,)
+        Unit quaternion that represents the swing, a rotation about an axis
+        orthogonal to the twist axis.
+
+    twist : array, shape (4,)
+        Unit quaternion that represents the twist, a rotation about the given
+        axis.
+
+    Raises
+    ------
+    ValueError
+        If the twist axis is the zero vector.
+
+    See Also
+    --------
+    swing_twist_composition
+        Reconstructs the original rotation from swing and twist.
+
+    concatenate_quaternions
+        Reconstructs the original rotation from swing and twist via
+        ``concatenate_quaternions(swing, twist)``.
+
+    References
+    ----------
+    .. [1] Dobrowolski, P. (2015). Swing-twist decomposition in Clifford
+       algebra. https://arxiv.org/abs/1506.05481
+    """
+
+    q = check_quaternion(q, unit=True)
+
+    axis = np.asarray(axis, dtype=float)
+
+    # Rescale by the largest-magnitude component before normalizing. Squaring
+    # the raw entries in np.linalg.norm underflows to zero for subnormal axes
+    # (spuriously raising below) or loses precision in the subnormal range
+    # (yielding a non-unit axis). Dividing by the max component first brings
+    # the entries to order 1, so the subsequent normalization stays exact and
+    # scale-invariant down to the smallest representable magnitude.
+
+    scale = np.max(np.abs(axis))
+    if scale == 0.0:
+        raise ValueError("Twist axis must not be the zero vector")
+
+    axis = norm_vector(axis / scale)
+
+    projection = np.dot(q[1:], axis) * axis
+    twist = np.array([q[0], projection[0], projection[1], projection[2]])
+    twist_norm = np.linalg.norm(twist)
+
+    if twist_norm < eps:
+        # Degenerate case: both the scalar part and the projection onto the
+        # axis vanish, which happens for a rotation by pi about an axis
+        # orthogonal to the twist axis. The twist is then undefined, so we
+        # return the identity and let the swing carry the full rotation.
+        twist = np.array([1.0, 0.0, 0.0, 0.0])
+    else:
+        twist /= twist_norm
+        if twist[0] < 0.0:
+            # Flip to the canonical hemisphere (w >= 0) so the twist angle
+            # stays in [-pi, pi].
+            twist = -twist
+
+    swing = concatenate_quaternions(q, q_conj(twist))
+    return swing, twist
+
+
+def swing_twist_composition(swing, twist):
+    r"""Recompose a rotation from its swing and twist components.
+
+    This is the inverse of :func:`swing_twist_decomposition`. Given a swing
+    and a twist quaternion, the original rotation is recovered by
+
+    .. math::
+
+        \boldsymbol{q} = \boldsymbol{q}_{swing} \boldsymbol{q}_{twist},
+
+    i.e. the twist is applied first and then the swing.
+
+    Note that the reconstructed quaternion may differ in sign from the
+    quaternion that was originally decomposed, since :math:`\boldsymbol{q}`
+    and :math:`-\boldsymbol{q}` represent the same rotation.
+
+    Parameters
+    ----------
+    swing : array-like, shape (4,)
+        Unit quaternion that represents the swing, a rotation about an axis
+        orthogonal to the twist axis.
+
+    twist : array-like, shape (4,)
+        Unit quaternion that represents the twist, a rotation about the twist
+        axis.
+
+    Returns
+    -------
+    q : array, shape (4,)
+        Unit quaternion that represents the recomposed rotation: (w, x, y, z).
+
+    See Also
+    --------
+    swing_twist_decomposition
+        Decomposes a rotation into swing and twist.
+    """
+    swing = check_quaternion(swing, unit=True)
+    twist = check_quaternion(twist, unit=True)
+    return concatenate_quaternions(swing, twist)

--- a/pytransform3d/rotations/_swing_twist.py
+++ b/pytransform3d/rotations/_swing_twist.py
@@ -67,6 +67,23 @@ def swing_twist_decomposition(q, axis, eps=np.finfo(float).eps):
         Reconstructs the original rotation from swing and twist via
         ``concatenate_quaternions(swing, twist)``.
 
+    Notes
+    -----
+    Beyond the algorithm of [1]_, this implementation fixes two conventions
+    for cases the paper leaves open:
+
+    1. **Degenerate twist.** When ``twist_norm < eps``, both the scalar part
+       and the projection of the vector part onto the twist axis vanish. This
+       happens for a rotation by :math:`\pi` about an axis orthogonal to the
+       twist axis, where the twist is undefined. We resolve it by returning the
+       identity as the twist and letting the swing carry the full rotation.
+
+    2. **Canonical hemisphere.** The twist is normalized to a non-negative
+       scalar part (:math:`w \geq 0`). Since :math:`\boldsymbol{q}` and
+       :math:`-\boldsymbol{q}` represent the same rotation, this makes the
+       returned twist unique and keeps the twist angle in
+       :math:`[-\pi, \pi]`.
+
     References
     ----------
     .. [1] Dobrowolski, P. (2015). Swing-twist decomposition in Clifford

--- a/pytransform3d/rotations/_swing_twist.py
+++ b/pytransform3d/rotations/_swing_twist.py
@@ -15,17 +15,19 @@ def swing_twist_decomposition(q, axis, eps=np.finfo(float).eps):
 
     .. math::
 
-        \boldsymbol{q} = \boldsymbol{q}_{swing} \boldsymbol{q}_{twist},
+        \boldsymbol{q} =
+        \boldsymbol{q}_\text{swing} \boldsymbol{q}_\text{twist},
 
     where the twist is applied first. The twist
-    :math:`\boldsymbol{q}_{twist}` is a rotation about :math:`\boldsymbol{e}`
-    and the swing :math:`\boldsymbol{q}_{swing}` is a rotation about an axis
-    that is orthogonal to :math:`\boldsymbol{e}` [1]_.
+    :math:`\boldsymbol{q}_\text{twist}` is a rotation about
+    :math:`\boldsymbol{e}` and the swing :math:`\boldsymbol{q}_\text{swing}`
+    is a rotation about an axis that is orthogonal to :math:`\boldsymbol{e}`
+    [1]_.
 
     The twist is obtained by projecting the vector part of the quaternion
     onto the twist axis and renormalizing; the swing is then recovered as
-    :math:`\boldsymbol{q}_{swing} = \boldsymbol{q}
-    \boldsymbol{q}_{twist}^{-1}`.
+    :math:`\boldsymbol{q}_\text{swing} = \boldsymbol{q}
+    \boldsymbol{q}_\text{twist}^{-1}`.
 
     This decomposition is useful, for example, to enforce joint limits, to
     separate the roll about a link axis from the remaining orientation, or to

--- a/pytransform3d/rotations/_swing_twist.pyi
+++ b/pytransform3d/rotations/_swing_twist.pyi
@@ -1,0 +1,11 @@
+from typing import Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+def swing_twist_decomposition(
+    q: npt.ArrayLike, axis: npt.ArrayLike, eps: float = ...
+) -> Tuple[np.ndarray, np.ndarray]: ...
+def swing_twist_composition(
+    swing: npt.ArrayLike, twist: npt.ArrayLike
+) -> np.ndarray: ...

--- a/pytransform3d/rotations/test/test_axis_angle.py
+++ b/pytransform3d/rotations/test/test_axis_angle.py
@@ -99,6 +99,30 @@ def test_compact_axis_angle_near_pi():
     )
 
 
+def test_assert_axis_angle_equal():
+    """Test assertion for axis-angle equality."""
+    pr.assert_axis_angle_equal(
+        np.array([1.0, 0.0, 0.0, np.pi]), np.array([-1.0, 0.0, 0.0, np.pi])
+    )
+    with pytest.raises(AssertionError):
+        pr.assert_axis_angle_equal(
+            np.array([1.0, 0.0, 0.0, 0.5 * np.pi]),
+            np.array([0.0, 1.0, 0.0, 0.5 * np.pi]),
+        )
+
+
+def test_assert_compact_axis_angle_equal():
+    """Test assertion for compact axis-angle equality."""
+    pr.assert_compact_axis_angle_equal(
+        np.array([np.pi, 0.0, 0.0]), np.array([-np.pi, 0.0, 0.0])
+    )
+    with pytest.raises(AssertionError):
+        pr.assert_compact_axis_angle_equal(
+            np.array([0.5 * np.pi, 0.0, 0.0]),
+            np.array([0.0, 0.5 * np.pi, 0.0]),
+        )
+
+
 def test_norm_compact_axis_angle():
     """Test normalization of compact angle-axis representation."""
     a = np.array([np.pi, 0.0, 0.0])
@@ -176,6 +200,17 @@ def test_axis_angle_from_compact_axis_angle():
         a = pr.axis_angle_from_compact_axis_angle(ca)
         assert pytest.approx(np.linalg.norm(ca)) == a[3]
         assert_array_almost_equal(ca[:3] / np.linalg.norm(ca), a[:3])
+
+
+def test_matrix_from_compact_axis_angle():
+    """Test conversion from compact axis-angle to rotation matrix."""
+    rng = np.random.default_rng(84)
+    for _ in range(5):
+        ca = pr.random_compact_axis_angle(rng)
+        a = pr.axis_angle_from_compact_axis_angle(ca)
+        assert_array_almost_equal(
+            pr.matrix_from_compact_axis_angle(ca), pr.matrix_from_axis_angle(a)
+        )
 
 
 def test_compact_axis_angle():

--- a/pytransform3d/rotations/test/test_matrix.py
+++ b/pytransform3d/rotations/test/test_matrix.py
@@ -228,6 +228,24 @@ def test_compare_axis_angle_from_matrix_to_lynch_park():
     # normal case is omitted here
 
 
+def test_axis_angle_from_matrix_pi_general_axis():
+    """Recover a general (non-coordinate) axis for a rotation of pi.
+
+    At pi the matrix is symmetric, so the skew-symmetric part is zero and the
+    axis signs have to come from the symmetric part. This completes the
+    coordinate-axis case fixed in #364. The axis is unique only up to sign at
+    pi, hence the round-trip comparison.
+    """
+    rng = np.random.default_rng(84)
+    for _ in range(50):
+        axis = pr.norm_vector(rng.standard_normal(3))
+        for angle in [np.pi, np.pi - 1e-6, np.pi - 1e-9, np.pi - 1e-12]:
+            R = pr.matrix_from_axis_angle(np.hstack((axis, (angle,))))
+            a2 = pr.axis_angle_from_matrix(R)
+            assert abs(a2[3] - angle) < 1e-4
+            assert_array_almost_equal(pr.matrix_from_axis_angle(a2), R)
+
+
 def test_conversions_matrix_compact_axis_angle():
     """Test conversions between rotation matrix and axis-angle."""
     R = np.eye(3)

--- a/pytransform3d/rotations/test/test_slerp.py
+++ b/pytransform3d/rotations/test/test_slerp.py
@@ -235,3 +235,18 @@ def test_rotor_slerp():
         assert_array_almost_equal(
             pr.rotor_apply(rotor_075, e), pr.q_prod_vector(q_075, e)
         )
+
+
+def test_slerp_weights_antipodal():
+    """slerp_weights must not overflow when angle = pi (antipodal inputs).
+
+    sin(pi) is ~1.22e-16 in float64, below machine epsilon, so dividing by
+    it without the guard produces weights of ~8e15 instead of values in [0,1].
+    """
+    for t in (0.0, 0.25, 0.5, 0.75, 1.0):
+        w1, w2 = pr.slerp_weights(np.pi, t)
+        assert np.isfinite(w1), f"w1 not finite at t={t}"
+        assert np.isfinite(w2), f"w2 not finite at t={t}"
+        assert abs(w1 + w2 - 1.0) < 1e-14, f"weights do not sum to 1 at t={t}"
+        assert 0.0 <= w1 <= 1.0, f"w1 out of [0,1] at t={t}"
+        assert 0.0 <= w2 <= 1.0, f"w2 out of [0,1] at t={t}"

--- a/pytransform3d/rotations/test/test_swing_twist.py
+++ b/pytransform3d/rotations/test/test_swing_twist.py
@@ -1,0 +1,449 @@
+"""Tests for the swing-twist decomposition of a rotation."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal
+
+import pytransform3d.rotations as pr
+
+# A representative selection of twist axes: the canonical basis vectors and a
+# few arbitrary directions (deliberately not normalized).
+AXES = [
+    pr.unitx,
+    pr.unity,
+    pr.unitz,
+    -pr.unitz,
+    np.array([1.0, 1.0, 1.0]),
+    np.array([0.2, -1.0, 0.5]),
+    np.array([-3.0, 0.0, 4.0]),
+]
+
+
+def _random_quaternions(n, seed):
+    rng = np.random.default_rng(seed)
+    return [pr.random_quaternion(rng) for _ in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Fundamental identity: q = swing * twist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=42))
+@pytest.mark.parametrize("axis", AXES)
+def test_reconstruction(q, axis):
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    # q == swing * twist (up to sign, which represents the same rotation)
+    assert pr.quaternion_dist(
+        pr.concatenate_quaternions(swing, twist), q
+    ) == pytest.approx(0.0, abs=1e-10)
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=42))
+@pytest.mark.parametrize("axis", AXES)
+def test_composition_roundtrip(q, axis):
+    # swing_twist_composition is the inverse of swing_twist_decomposition;
+    # it recovers the original rotation (up to sign).
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    q_reconstructed = pr.swing_twist_composition(swing, twist)
+    assert pr.quaternion_dist(q_reconstructed, q) == pytest.approx(
+        0.0, abs=1e-10
+    )
+
+
+def test_composition_matches_concatenation():
+    # swing_twist_composition applies the twist first, then the swing, i.e.
+    # it is exactly concatenate_quaternions(swing, twist).
+    swing = pr.quaternion_from_axis_angle([0.0, 1.0, 0.0, 0.7])
+    twist = pr.quaternion_from_axis_angle([1.0, 0.0, 0.0, 0.3])
+    assert_array_almost_equal(
+        pr.swing_twist_composition(swing, twist),
+        pr.concatenate_quaternions(swing, twist),
+    )
+
+
+@pytest.mark.parametrize("q", _random_quaternions(10, seed=101))
+@pytest.mark.parametrize("axis", AXES)
+def test_reconstruction_as_matrix_product(q, axis):
+    # The decomposition must also hold for the equivalent rotation matrices:
+    # R = R_swing @ R_twist.
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    R = pr.matrix_from_quaternion(q)
+    R_swing = pr.matrix_from_quaternion(swing)
+    R_twist = pr.matrix_from_quaternion(twist)
+    assert_array_almost_equal(R, R_swing.dot(R_twist))
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=7))
+@pytest.mark.parametrize("axis", AXES)
+def test_outputs_are_unit_quaternions(q, axis):
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    assert np.linalg.norm(swing) == pytest.approx(1.0)
+    assert np.linalg.norm(twist) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Geometric properties of swing and twist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=3))
+@pytest.mark.parametrize("axis", AXES)
+def test_twist_axis_parallel_to_given_axis(q, axis):
+    _, twist = pr.swing_twist_decomposition(q, axis)
+    # the vector part of the twist is parallel to the (normalized) twist axis
+    assert_array_almost_equal(
+        np.cross(twist[1:], pr.norm_vector(axis)), np.zeros(3)
+    )
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=5))
+@pytest.mark.parametrize("axis", AXES)
+def test_swing_axis_orthogonal_to_given_axis(q, axis):
+    swing, _ = pr.swing_twist_decomposition(q, axis)
+    # the rotation axis of the swing is orthogonal to the twist axis
+    assert np.dot(swing[1:], pr.norm_vector(axis)) == pytest.approx(
+        0.0, abs=1e-10
+    )
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=9))
+@pytest.mark.parametrize("axis", AXES)
+def test_twist_leaves_axis_invariant(q, axis):
+    # A rotation about the axis does not move the axis itself.
+    _, twist = pr.swing_twist_decomposition(q, axis)
+    axis = pr.norm_vector(axis)
+    assert_array_almost_equal(pr.q_prod_vector(twist, axis), axis)
+
+
+@pytest.mark.parametrize("q", _random_quaternions(30, seed=11))
+@pytest.mark.parametrize("axis", AXES)
+def test_swing_maps_axis_like_full_rotation(q, axis):
+    # Because the twist fixes the axis, the swing must move the axis exactly
+    # like the full rotation does.
+    swing, _ = pr.swing_twist_decomposition(q, axis)
+    axis = pr.norm_vector(axis)
+    assert_array_almost_equal(
+        pr.q_prod_vector(swing, axis), pr.q_prod_vector(q, axis)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Special cases: identity, pure twist, pure swing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axis", AXES)
+def test_identity_rotation(axis):
+    swing, twist = pr.swing_twist_decomposition(pr.q_id, axis)
+    pr.assert_quaternion_equal(swing, pr.q_id)
+    pr.assert_quaternion_equal(twist, pr.q_id)
+
+
+@pytest.mark.parametrize("axis", AXES)
+@pytest.mark.parametrize("angle", [-2.5, -0.9, 0.3, 1.7, 3.0])
+def test_pure_twist(axis, angle):
+    # a rotation about the axis has no swing
+    q = pr.quaternion_from_axis_angle(
+        np.hstack((pr.norm_vector(axis), [angle]))
+    )
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    pr.assert_quaternion_equal(swing, pr.q_id)
+    pr.assert_quaternion_equal(twist, q)
+
+
+@pytest.mark.parametrize("angle", [-2.5, -0.9, 0.3, 1.7, 3.0])
+def test_pure_swing(angle):
+    # a rotation about an orthogonal axis has no twist
+    axis = pr.unitz
+    q = pr.quaternion_from_axis_angle(np.hstack((pr.unitx, [angle])))
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    pr.assert_quaternion_equal(twist, pr.q_id)
+    pr.assert_quaternion_equal(swing, q)
+
+
+@pytest.mark.parametrize("twist_angle", [-2.0, 0.4, 1.1, 2.8])
+@pytest.mark.parametrize("swing_angle", [0.2, 0.6, 1.5])
+def test_recover_known_components(twist_angle, swing_angle):
+    axis = pr.norm_vector(np.array([0.2, -1.0, 0.5]))
+    twist_true = pr.quaternion_from_axis_angle(np.hstack((axis, [twist_angle])))
+    swing_axis = pr.norm_vector(pr.perpendicular_to_vectors(axis, pr.unitx))
+    swing_true = pr.quaternion_from_axis_angle(
+        np.hstack((swing_axis, [swing_angle]))
+    )
+    q = pr.concatenate_quaternions(swing_true, twist_true)
+
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    assert pr.quaternion_dist(twist, twist_true) == pytest.approx(
+        0.0, abs=1e-10
+    )
+    assert pr.quaternion_dist(swing, swing_true) == pytest.approx(
+        0.0, abs=1e-10
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency / stability of the decomposition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", _random_quaternions(15, seed=13))
+@pytest.mark.parametrize("axis", AXES)
+def test_decomposing_twist_again_is_stable(q, axis):
+    # Decomposing the twist about the same axis returns the twist unchanged
+    # and an identity swing.
+    _, twist = pr.swing_twist_decomposition(q, axis)
+    swing2, twist2 = pr.swing_twist_decomposition(twist, axis)
+    pr.assert_quaternion_equal(swing2, pr.q_id)
+    pr.assert_quaternion_equal(twist2, twist)
+
+
+@pytest.mark.parametrize("q", _random_quaternions(15, seed=17))
+@pytest.mark.parametrize("axis", AXES)
+def test_swing_has_no_twist_component(q, axis):
+    # Decomposing the swing about the same axis yields an identity twist and
+    # returns the swing unchanged.
+    swing, _ = pr.swing_twist_decomposition(q, axis)
+    swing2, twist2 = pr.swing_twist_decomposition(swing, axis)
+    assert pr.quaternion_dist(twist2, pr.q_id) == pytest.approx(0.0, abs=1e-10)
+    pr.assert_quaternion_equal(swing2, swing)
+
+
+# ---------------------------------------------------------------------------
+# Double cover: q and -q represent the same rotation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", _random_quaternions(15, seed=19))
+@pytest.mark.parametrize("axis", AXES)
+def test_double_cover(q, axis):
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    swing_neg, twist_neg = pr.swing_twist_decomposition(-q, axis)
+    # -q is the same rotation, so both components describe the same rotations
+    assert pr.quaternion_dist(swing_neg, swing) == pytest.approx(0.0, abs=1e-10)
+    assert pr.quaternion_dist(twist_neg, twist) == pytest.approx(0.0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Hemisphere canonicalization of the twist
+#
+# The twist is forced into the canonical hemisphere (non-negative scalar
+# part), so that its rotation angle about the axis is in [-pi, pi] and the
+# result is independent of the sign of the input quaternion. random_quaternion
+# produces both signs of the scalar part, so these tests exercise the flip.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", _random_quaternions(50, seed=23))
+@pytest.mark.parametrize("axis", AXES)
+def test_twist_is_in_canonical_hemisphere(q, axis):
+    # The scalar part of the twist must be non-negative.
+    _, twist = pr.swing_twist_decomposition(q, axis)
+    assert twist[0] >= 0.0
+
+
+@pytest.mark.parametrize("q", _random_quaternions(50, seed=31))
+@pytest.mark.parametrize("axis", AXES)
+def test_twist_is_identical_for_q_and_negated_q(q, axis):
+    # Thanks to the canonicalization, the twist is not just the same rotation
+    # for q and -q, it is the exact same quaternion (no sign ambiguity).
+    _, twist = pr.swing_twist_decomposition(q, axis)
+    _, twist_neg = pr.swing_twist_decomposition(-q, axis)
+    assert_array_almost_equal(twist, twist_neg)
+
+
+def test_negative_scalar_input_triggers_flip():
+    # Hand-built quaternion with a negative scalar part and a non-zero
+    # projection onto the axis: this must be flipped into the canonical
+    # hemisphere while still reconstructing the original rotation.
+    axis = pr.unitz
+    q = pr.norm_vector(np.array([-0.3, 0.4, 0.1, 0.2]))
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    assert twist[0] > 0.0
+    assert pr.quaternion_dist(
+        pr.concatenate_quaternions(swing, twist), q
+    ) == pytest.approx(0.0, abs=1e-10)
+
+
+def test_negated_pure_twist_is_canonicalized():
+    # A pure twist whose quaternion has a negative scalar part is the same
+    # rotation as its canonical counterpart; the decomposition returns the
+    # canonical form (non-negative scalar) and no swing.
+    axis = pr.norm_vector(np.array([1.0, 2.0, -1.0]))
+    q_canonical = pr.quaternion_from_axis_angle(np.hstack((axis, [0.9])))
+    q = -q_canonical  # same rotation, negative scalar part
+    assert q[0] < 0.0
+
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    assert twist[0] >= 0.0
+    pr.assert_quaternion_equal(swing, pr.q_id)
+    assert pr.quaternion_dist(twist, q_canonical) == pytest.approx(
+        0.0, abs=1e-10
+    )
+
+
+def test_twist_angle_within_pi():
+    # A non-negative scalar part is equivalent to a twist angle in [-pi, pi].
+    rng = np.random.default_rng(37)
+    for _ in range(200):
+        q = pr.random_quaternion(rng)
+        axis = pr.norm_vector(rng.normal(size=3))
+        _, twist = pr.swing_twist_decomposition(q, axis)
+        angle = 2.0 * np.arctan2(np.linalg.norm(twist[1:]), twist[0])
+        assert -np.pi - 1e-12 <= angle <= np.pi + 1e-12
+
+
+# ---------------------------------------------------------------------------
+# Numerical edge cases and singularities
+# ---------------------------------------------------------------------------
+
+
+def test_pi_rotation_about_twist_axis_is_not_singular():
+    # A rotation by pi *about* the twist axis is a well defined pure twist.
+    axis = pr.unitz
+    q = pr.quaternion_from_axis_angle(np.hstack((axis, [np.pi])))
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    pr.assert_quaternion_equal(swing, pr.q_id)
+    pr.assert_quaternion_equal(twist, q)
+
+
+@pytest.mark.parametrize("orthogonal_axis", [pr.unitx, pr.unity])
+def test_pi_rotation_orthogonal_singularity(orthogonal_axis):
+    # rotation by pi about an axis orthogonal to the twist axis: the twist is
+    # undefined and falls back to the identity, the swing captures everything.
+    axis = pr.unitz
+    q = pr.quaternion_from_axis_angle(np.hstack((orthogonal_axis, [np.pi])))
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    pr.assert_quaternion_equal(twist, pr.q_id)
+    assert pr.quaternion_dist(
+        pr.concatenate_quaternions(swing, twist), q
+    ) == pytest.approx(0.0, abs=1e-10)
+
+
+def test_near_pi_orthogonal_still_reconstructs():
+    # Just short of the singularity the decomposition must remain accurate.
+    axis = pr.unitz
+    q = pr.quaternion_from_axis_angle(
+        np.hstack((pr.unitx, [np.pi - 1e-6]))
+    )
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    assert np.linalg.norm(twist) == pytest.approx(1.0)
+    assert pr.quaternion_dist(
+        pr.concatenate_quaternions(swing, twist), q
+    ) == pytest.approx(0.0, abs=1e-8)
+
+
+@pytest.mark.parametrize("axis", AXES)
+def test_tiny_rotation_near_identity(axis):
+    q = pr.quaternion_from_axis_angle(
+        np.hstack((pr.norm_vector(np.array([1.0, -2.0, 3.0])), [1e-9]))
+    )
+    swing, twist = pr.swing_twist_decomposition(q, axis)
+    pr.assert_quaternion_equal(swing, pr.q_id)
+    pr.assert_quaternion_equal(twist, pr.q_id)
+
+
+# ---------------------------------------------------------------------------
+# Input handling: axis scaling, array-likes, non-unit quaternions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("scale", [1e-3, 0.5, 1.0, 7.0, 1000.0])
+def test_axis_scale_invariance(scale):
+    q = pr.random_quaternion(np.random.default_rng(8))
+    unit_axis = pr.norm_vector(np.array([0.0, 1.0, 1.0]))
+    swing_ref, twist_ref = pr.swing_twist_decomposition(q, unit_axis)
+    swing, twist = pr.swing_twist_decomposition(q, scale * unit_axis)
+    assert_array_almost_equal(swing, swing_ref)
+    assert_array_almost_equal(twist, twist_ref)
+
+
+# Extreme scales, including the subnormal range where a naive
+# sqrt(sum-of-squares) normalization would underflow or lose precision. The
+# decomposition depends only on the axis direction, so the result must match
+# the unit-axis result and stay finite for every representable magnitude.
+@pytest.mark.parametrize(
+    "scale",
+    [1e-160, 1e-200, 1e-300, 3.7e-308, 1e-320, 5e-324, 1e160, 1e300],
+)
+@pytest.mark.parametrize("axis", [pr.unitx, pr.unity, pr.unitz])
+def test_subnormal_and_extreme_axis_scale(scale, axis):
+    q = pr.random_quaternion(np.random.default_rng(53))
+    swing_ref, twist_ref = pr.swing_twist_decomposition(q, axis)
+    swing, twist = pr.swing_twist_decomposition(q, scale * axis)
+    assert np.all(np.isfinite(swing)) and np.all(np.isfinite(twist))
+    assert_array_almost_equal(swing, swing_ref)
+    assert_array_almost_equal(twist, twist_ref)
+
+
+def test_accepts_list_input():
+    swing, twist = pr.swing_twist_decomposition(
+        [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0]
+    )
+    pr.assert_quaternion_equal(swing, pr.q_id)
+    pr.assert_quaternion_equal(twist, pr.q_id)
+
+
+def test_non_unit_quaternion_is_normalized():
+    # check_quaternion normalizes, so a scaled quaternion gives the same
+    # result as the normalized one.
+    q = pr.random_quaternion(np.random.default_rng(21))
+    axis = pr.unity
+    swing_ref, twist_ref = pr.swing_twist_decomposition(q, axis)
+    swing, twist = pr.swing_twist_decomposition(5.0 * q, axis)
+    assert_array_almost_equal(swing, swing_ref)
+    assert_array_almost_equal(twist, twist_ref)
+
+
+# ---------------------------------------------------------------------------
+# The eps parameter
+# ---------------------------------------------------------------------------
+
+
+def test_short_nonzero_axis_is_accepted():
+    # Only an exactly-zero axis is rejected; a short but non-zero axis is
+    # normalized like any other and does not depend on eps.
+    q = pr.random_quaternion(np.random.default_rng(41))
+    short_axis = np.array([1e-6, 0.0, 0.0])
+    swing, twist = pr.swing_twist_decomposition(q, short_axis, eps=0.5)
+    ref_swing, ref_twist = pr.swing_twist_decomposition(q, pr.unitx)
+    assert_array_almost_equal(swing, ref_swing)
+    assert_array_almost_equal(twist, ref_twist)
+
+
+def test_eps_controls_singularity_fallback():
+    # A rotation just short of a pi rotation orthogonal to the twist axis has
+    # a small but non-zero twist norm (~1e-4 here).
+    axis = pr.unitz
+    q = pr.quaternion_from_axis_angle(np.hstack((pr.unitx, [np.pi - 2e-4])))
+
+    # A large eps forces the singular fallback: the twist becomes the exact
+    # identity quaternion.
+    _, twist_fallback = pr.swing_twist_decomposition(q, axis, eps=1e-2)
+    assert_array_almost_equal(twist_fallback, pr.q_id)
+
+    # A tiny eps keeps the (normalized) twist and still reconstructs q.
+    swing, twist = pr.swing_twist_decomposition(q, axis, eps=1e-12)
+    assert np.linalg.norm(twist) == pytest.approx(1.0)
+    assert pr.quaternion_dist(
+        pr.concatenate_quaternions(swing, twist), q
+    ) == pytest.approx(0.0, abs=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Invalid input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "axis", [np.zeros(3), [0.0, 0.0, 0.0], np.array([0.0, -0.0, 0.0])]
+)
+def test_zero_axis_raises(axis):
+    with pytest.raises(ValueError, match="zero vector"):
+        pr.swing_twist_decomposition(pr.q_id, axis)
+
+
+@pytest.mark.parametrize("bad_q", [np.zeros(3), np.ones(5), np.ones((2, 4))])
+def test_invalid_quaternion_shape_raises(bad_q):
+    with pytest.raises(ValueError, match="quaternion"):
+        pr.swing_twist_decomposition(bad_q, pr.unitz)

--- a/pytransform3d/rotations/test/test_swing_twist.py
+++ b/pytransform3d/rotations/test/test_swing_twist.py
@@ -323,9 +323,7 @@ def test_pi_rotation_orthogonal_singularity(orthogonal_axis):
 def test_near_pi_orthogonal_still_reconstructs():
     # Just short of the singularity the decomposition must remain accurate.
     axis = pr.unitz
-    q = pr.quaternion_from_axis_angle(
-        np.hstack((pr.unitx, [np.pi - 1e-6]))
-    )
+    q = pr.quaternion_from_axis_angle(np.hstack((pr.unitx, [np.pi - 1e-6])))
     swing, twist = pr.swing_twist_decomposition(q, axis)
     assert np.linalg.norm(twist) == pytest.approx(1.0)
     assert pr.quaternion_dist(

--- a/pytransform3d/transformations/_jacobians.py
+++ b/pytransform3d/transformations/_jacobians.py
@@ -64,7 +64,9 @@ def left_jacobian_SE3(Stheta):
     Stheta = check_exponential_coordinates(Stheta)
 
     _, theta = screw_axis_from_exponential_coordinates(Stheta)
-    if theta < np.finfo(float).eps:
+    # Delegates to left_jacobian_SO3, which has catastrophic cancellation
+    # for small theta (see that function).  Mirror the same threshold.
+    if theta < math.sqrt(6.0 * np.finfo(float).eps):
         return left_jacobian_SE3_series(Stheta, 10)
 
     phi = Stheta[:3]
@@ -149,7 +151,7 @@ def left_jacobian_SE3_inv(Stheta):
     Stheta = check_exponential_coordinates(Stheta)
 
     _, theta = screw_axis_from_exponential_coordinates(Stheta)
-    if theta < np.finfo(float).eps:
+    if theta < math.sqrt(6.0 * np.finfo(float).eps):
         return left_jacobian_SE3_inv_series(Stheta, 10)
 
     phi = Stheta[:3]

--- a/pytransform3d/transformations/_screws.py
+++ b/pytransform3d/transformations/_screws.py
@@ -114,18 +114,30 @@ def check_screw_axis(screw_axis):
             "object with shape %s" % (screw_axis.shape,)
         )
 
+    # _NEAR_ZERO_TOL: practical threshold for "omega was meant to be zero but
+    # has floating-point noise".  10 ULPs is a widely used heuristic.
+    # _NEAR_ONE_TOL: derived from IEEE 754 error analysis.  Computing
+    # np.linalg.norm on a 3-vector with true norm 1 accumulates at most
+    # 5u/2 = 5/4 * eps (u = eps/2 unit roundoff) from 3 squarings, 2
+    # additions, and 1 correctly-rounded sqrt.  2 * eps gives a factor-of-1.6
+    # safety margin over that bound.  Both thresholds must be kept in sync:
+    # using different values for the two "near zero" tests creates a dead zone
+    # where invalid axes are silently accepted.
+    _NEAR_ZERO_TOL = 10.0 * np.finfo(float).eps
+    _NEAR_ONE_TOL = 2.0 * np.finfo(float).eps
+
     omega_norm = np.linalg.norm(screw_axis[:3])
     if (
-        abs(omega_norm - 1.0) > 10.0 * np.finfo(float).eps
-        and abs(omega_norm) > 10.0 * np.finfo(float).eps
+        abs(omega_norm - 1.0) > _NEAR_ONE_TOL
+        and abs(omega_norm) > _NEAR_ZERO_TOL
     ):
         raise ValueError(
             "Norm of rotation axis must either be 0 or 1, but it is %g."
             % omega_norm
         )
-    if abs(omega_norm) < np.finfo(float).eps:
+    if abs(omega_norm) < _NEAR_ZERO_TOL:
         v_norm = np.linalg.norm(screw_axis[3:])
-        if abs(v_norm - 1.0) > np.finfo(float).eps:
+        if abs(v_norm - 1.0) > _NEAR_ONE_TOL:
             raise ValueError(
                 "If the norm of the rotation axis is 0, then the direction "
                 "vector must have norm 1, but it is %g." % v_norm

--- a/pytransform3d/transformations/_transform.py
+++ b/pytransform3d/transformations/_transform.py
@@ -49,7 +49,7 @@ def check_transform(A2B, strict_check=True):
     check_matrix(A2B[:3, :3], strict_check=strict_check)
     if not np.allclose(A2B[3], np.array([0.0, 0.0, 0.0, 1.0])):
         error_msg = (
-            "Excpected homogeneous transformation matrix with "
+            "Expected homogeneous transformation matrix with "
             "[0, 0, 0, 1] at the bottom, got %r" % A2B
         )
         if strict_check:

--- a/pytransform3d/transformations/test/test_screws.py
+++ b/pytransform3d/transformations/test/test_screws.py
@@ -61,6 +61,22 @@ def test_check_screw_axis():
     assert_array_almost_equal(S, S_both)
 
 
+def test_check_screw_axis_rejects_dead_zone():
+    """Screw axis with omega_norm in (eps, 10*eps) and non-unit v rejection.
+
+    The near-zero guard used abs(omega_norm) < eps, while the preceding check
+    used abs(omega_norm) > 10*eps to define 'not near zero'.  For omega_norm
+    in (eps, 10*eps) the first check passes (omega looks near-zero) but the
+    v-norm check was never entered, so any v was silently accepted.  After
+    aligning both thresholds to 10*eps the dead zone is closed.
+    """
+    eps = np.finfo(float).eps
+    omega = np.array([3.0 * eps, 0.0, 0.0])  # norm in (eps, 10*eps)
+    v = np.array([0.5, 0.0, 0.0])  # non-unit: invalid for pure translation
+    with pytest.raises(ValueError, match="direction vector must have norm 1"):
+        pt.check_screw_axis(np.r_[omega, v])
+
+
 def test_check_exponential_coordinates():
     with pytest.raises(ValueError, match="Expected array-like with shape"):
         pt.check_exponential_coordinates([0])

--- a/pytransform3d/uncertainty/_frechet_mean.py
+++ b/pytransform3d/uncertainty/_frechet_mean.py
@@ -158,7 +158,7 @@ def estimate_gaussian_rotation_matrix_from_samples(samples):
         n_iter=20,
     )
 
-    cov = np.cov(mean_diffs, rowvar=False, bias=True)
+    cov = np.cov(mean_diffs, rowvar=False, bias=False)
     return mean, cov
 
 
@@ -203,5 +203,5 @@ def estimate_gaussian_transform_from_samples(samples):
         n_iter=20,
     )
 
-    cov = np.cov(mean_diffs, rowvar=False, bias=True)
+    cov = np.cov(mean_diffs, rowvar=False, bias=False)
     return mean, cov


### PR DESCRIPTION
## Features

* Add functions for swing-twist decomposition and composition of quaternions (contribution by @fagg):
    * `swing_twist_decomposition` - splits a unit quaternion into a twist (rotation about a given axis) and a swing (rotation about an axis orthogonal to it), such that `q = q_swing . q_twist`.
    * `swing_twist_composition` - the inverse operation, for reconstruction of the original rotation from its swing and twist components.

## Bugfixes

* Fix NaN in axis_angles_from_matrices for exact pi rotations
* Fix slerp_weights numerical overflow for antipodal quaternions
* Replace Jacobian series threshold with sqrt(6*eps)
* Fix biased covariance estimator in estimate_gaussian_*_from_samples
* Fix dead zone and derive tolerances in check_screw_axis
* Fix recovery of rotation axis sign in `axis_angles_from_matrices` and `axis_angle_from_matrix` for cases near $\pi$

## Documentation

* Link to web archive for Furgale's lost slides