### PR TITLE
Fix batch axis-angle conversion without an output buffer

### DIFF
--- a/pytransform3d/batch_rotations/_axis_angle.py
+++ b/pytransform3d/batch_rotations/_axis_angle.py
@@ -63,11 +63,11 @@ def matrices_from_compact_axis_angles(A=None, axes=None, angles=None, out=None):
         Axes of rotation and rotation angles in compact representation:
         angle * (x, y, z). If omitted, both axes and angles must be provided.
 
-    axes : array, shape (..., 3)
+    axes : array, shape (..., 3), optional (default: None)
         If the unit axes of rotation have been precomputed, you can pass them
         here.
 
-    angles : array, shape (...)
+    angles : array, shape (...), optional (default: None)
         If the angles have been precomputed, you can pass them here.
 
     out : array, shape (..., 3, 3), optional (default: new array)
@@ -77,13 +77,24 @@ def matrices_from_compact_axis_angles(A=None, axes=None, angles=None, out=None):
     -------
     Rs : array, shape (..., 3, 3)
         Rotation matrices
+
+    Raises
+    ------
+    ValueError
+        If A is omitted and axes or angles are not provided.
     """
+    if A is None and (axes is None or angles is None):
+        raise ValueError("Either A or both axes and angles must be provided.")
+
     if angles is None:
         thetas = np.linalg.norm(A, axis=-1)
     else:
         thetas = np.asarray(angles)
 
     if axes is None:
+        A = np.asarray(A)
+        if A.dtype.kind in "biu":
+            A = A.astype(float)
         omega_unit = norm_vectors(A)
     else:
         omega_unit = axes
@@ -105,9 +116,7 @@ def matrices_from_compact_axis_angles(A=None, axes=None, angles=None, out=None):
     ciuyuz = ciuy * uz
 
     if out is None:
-        # Without A, use the broadcast shape of the axes and angles.
-        shape = np.shape(A)[:-1] if A is not None else uxs.shape
-        out = np.empty(shape + (3, 3))
+        out = np.empty(uxs.shape + (3, 3))
 
     out[..., 0, 0] = ciux * ux + c
     out[..., 0, 1] = ciuxuy - uzs

--- a/pytransform3d/batch_rotations/_axis_angle.py
+++ b/pytransform3d/batch_rotations/_axis_angle.py
@@ -59,9 +59,9 @@ def matrices_from_compact_axis_angles(A=None, axes=None, angles=None, out=None):
 
     Parameters
     ----------
-    A : array-like, shape (..., 3)
+    A : array-like, shape (..., 3), optional (default: None)
         Axes of rotation and rotation angles in compact representation:
-        angle * (x, y, z)
+        angle * (x, y, z). If omitted, both axes and angles must be provided.
 
     axes : array, shape (..., 3)
         If the unit axes of rotation have been precomputed, you can pass them
@@ -105,7 +105,9 @@ def matrices_from_compact_axis_angles(A=None, axes=None, angles=None, out=None):
     ciuyuz = ciuy * uz
 
     if out is None:
-        out = np.empty(A.shape[:-1] + (3, 3))
+        # Without A, use the broadcast shape of the axes and angles.
+        shape = np.shape(A)[:-1] if A is not None else uxs.shape
+        out = np.empty(shape + (3, 3))
 
     out[..., 0, 0] = ciux * ux + c
     out[..., 0, 1] = ciuxuy - uzs

--- a/pytransform3d/batch_rotations/test/test_batch_rotations.py
+++ b/pytransform3d/batch_rotations/test/test_batch_rotations.py
@@ -363,6 +363,24 @@ def test_matrices_from_compact_axis_angle_lists(shape):
         assert_array_almost_equal(Rs[index], expected)
 
 
+@pytest.mark.parametrize("a", [[0, 0, 1], [0, 1, 1], [0, 0, 0]])
+def test_matrices_from_compact_axis_angle_integer_lists(a):
+    Rs = pbr.matrices_from_compact_axis_angles([a])
+
+    assert Rs.shape == (1, 3, 3)
+    assert_array_almost_equal(Rs[0], pr.matrix_from_compact_axis_angle(a))
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{}, {"axes": np.array([0.0, 0.0, 1.0])}, {"angles": 0.5}]
+)
+def test_matrices_from_compact_axis_angles_missing_parameters(kwargs):
+    with pytest.raises(
+        ValueError, match="Either A or both axes and angles must be provided"
+    ):
+        pbr.matrices_from_compact_axis_angles(**kwargs)
+
+
 @pytest.mark.parametrize("angles", [0.5, [0.5]])
 def test_matrices_from_compact_axis_angles_broadcast_angles(angles):
     A = np.array([[0.0, 0.0, 0.2], [0.0, 0.3, 0.0]])
@@ -385,9 +403,9 @@ def test_matrices_from_precomputed_axis_angles_with_compact_batch():
         A, axes=np.array([0.0, 0.0, 1.0]), angles=0.5
     )
 
-    assert Rs.shape == (2, 3, 3)
+    assert Rs.shape == (3, 3)
     expected = pr.matrix_from_axis_angle([0.0, 0.0, 1.0, 0.5])
-    assert_array_almost_equal(Rs, [expected, expected])
+    assert_array_almost_equal(Rs, expected)
 
 
 def test_axis_angles_from_matrices_0dims():

--- a/pytransform3d/batch_rotations/test/test_batch_rotations.py
+++ b/pytransform3d/batch_rotations/test/test_batch_rotations.py
@@ -329,6 +329,67 @@ def test_quaternions_from_matrices_4d():
         pr.assert_quaternion_equal(q, q2[1, 1])
 
 
+@pytest.mark.parametrize("shape", [(), (3,), (2, 3), (0,), (2, 0)])
+@pytest.mark.parametrize("use_out", [False, True])
+def test_matrices_from_precomputed_axis_angles(shape, use_out):
+    rng = np.random.default_rng(84)
+    axes = rng.standard_normal(size=shape + (3,))
+    axes /= np.linalg.norm(axes, axis=-1)[..., np.newaxis]
+    angles = rng.uniform(-np.pi, np.pi, size=shape)
+    out = np.empty(shape + (3, 3)) if use_out else None
+
+    Rs = pbr.matrices_from_compact_axis_angles(
+        axes=axes, angles=angles, out=out
+    )
+
+    assert Rs.shape == shape + (3, 3)
+    if use_out:
+        assert Rs is out
+    for index in np.ndindex(shape):
+        expected = pr.matrix_from_axis_angle(np.r_[axes[index], angles[index]])
+        assert_array_almost_equal(Rs[index], expected)
+
+
+@pytest.mark.parametrize("shape", [(), (3,), (2, 3)])
+def test_matrices_from_compact_axis_angle_lists(shape):
+    rng = np.random.default_rng(85)
+    A = rng.standard_normal(size=shape + (3,))
+
+    Rs = pbr.matrices_from_compact_axis_angles(A.tolist())
+
+    assert Rs.shape == shape + (3, 3)
+    for index in np.ndindex(shape):
+        expected = pr.matrix_from_compact_axis_angle(A[index])
+        assert_array_almost_equal(Rs[index], expected)
+
+
+@pytest.mark.parametrize("angles", [0.5, [0.5]])
+def test_matrices_from_compact_axis_angles_broadcast_angles(angles):
+    A = np.array([[0.0, 0.0, 0.2], [0.0, 0.3, 0.0]])
+
+    Rs = pbr.matrices_from_compact_axis_angles(A, angles=angles)
+
+    assert Rs.shape == (2, 3, 3)
+    assert_array_almost_equal(
+        Rs[0], pr.matrix_from_axis_angle([0.0, 0.0, 1.0, 0.5])
+    )
+    assert_array_almost_equal(
+        Rs[1], pr.matrix_from_axis_angle([0.0, 1.0, 0.0, 0.5])
+    )
+
+
+def test_matrices_from_precomputed_axis_angles_with_compact_batch():
+    A = np.tile([0.0, 0.0, 0.5], (2, 1))
+
+    Rs = pbr.matrices_from_compact_axis_angles(
+        A, axes=np.array([0.0, 0.0, 1.0]), angles=0.5
+    )
+
+    assert Rs.shape == (2, 3, 3)
+    expected = pr.matrix_from_axis_angle([0.0, 0.0, 1.0, 0.5])
+    assert_array_almost_equal(Rs, [expected, expected])
+
+
 def test_axis_angles_from_matrices_0dims():
     rng = np.random.default_rng(84)
     A = rng.standard_normal(size=3)


### PR DESCRIPTION
`matrices_from_compact_axis_angles` raises `AttributeError` when called with precomputed axes and angles without an output buffer, or with compact axis-angle inputs supplied as Python lists. Non-axis-aligned integer compact coordinates also produce incorrect matrices because their normalized axes are stored in an integer array.

For example, this documented parameter combination should return a 90-degree rotation about z, but currently tries to access `None.shape`:

```python
import numpy as np
from pytransform3d.batch_rotations import matrices_from_compact_axis_angles

matrices_from_compact_axis_angles(
    axes=np.array([0.0, 0.0, 1.0]), angles=np.pi / 2
)
```

Allocate the output from the already computed broadcast shape, `uxs.shape`. When both axes and angles are supplied, the shape follows those parameters even if an unused `A` argument is also present. Missing `A` together with incomplete precomputed parameters now raises a descriptive `ValueError`, and the docstring marks axes and angles as optional.

Boolean and integer compact coordinates are converted to floating point before axis normalization. Existing floating-input calculations and supplied output-buffer behavior are preserved. Tests include integer lists `[[0, 0, 1]]`, `[[0, 1, 1]]`, and the zero vector, as well as the missing-parameter cases, batches, empty batches, broadcasting, and explicit output buffers. Matrix values are checked against scalar rotation conversions.

Validation on `develop` base `cf7393f47cbf7111badb1e96c9be14402ffe5787`, using Python 3.10.12 and NumPy 2.2.6:

- Initial regression tests with the original upstream implementation: **8 failed, 53 passed** in the batch-rotation test file.
- Review regressions against the first PR commit: **5 failed, 62 passed**. These expose the incomplete-argument cases, the non-axis-aligned integer input, and the requested output-shape change.
- Full package tests with the final revision: **3,094 passed, 3 skipped**. The three skipped mesh-loader tests require optional Open3D.
- Separate checks confirm the integer non-axis-aligned case now agrees with the scalar reference, and float16/float32/float64/longdouble calculations and strided output buffers retain their prior behavior.
- Ruff, Black, and `git diff --check` passed. Wheel and sdist builds passed for the initial submission; they have not been repeated for this review revision.

AI disclosure: Codex assisted with source investigation, implementation, tests, this description, and the review revisions. Validation was executed locally.
